### PR TITLE
feat: validate telegram env variables

### DIFF
--- a/src/notify/telegram.js
+++ b/src/notify/telegram.js
@@ -1,6 +1,7 @@
 import TelegramBot from 'node-telegram-bot-api';
 import { cfg } from '../config.js';
 
+if (!cfg.tgToken) throw new Error('Missing TELEGRAM_BOT_TOKEN');
 export const bot = new TelegramBot(cfg.tgToken, { polling: false });
 
 export async function notifyPublic(text) {

--- a/test-telegram.js
+++ b/test-telegram.js
@@ -1,8 +1,21 @@
 import TelegramBot from 'node-telegram-bot-api';
 import 'dotenv/config';
 
-const bot = new TelegramBot(process.env.TELEGRAM_BOT_TOKEN, { polling: false });
+const token = process.env.TELEGRAM_BOT_TOKEN;
+const chatId = process.env.TELEGRAM_PRIVATE_CHAT_ID;
 
-bot.createChatInviteLink(process.env.TELEGRAM_PRIVATE_CHAT_ID, { member_limit: 1 })
-    .then(link => console.log('Invite link:', link.invite_link))
-    .catch(err => console.error('createChatInviteLink error:', err.message));
+if (!token) {
+  console.error('Missing TELEGRAM_BOT_TOKEN');
+  process.exit(1);
+}
+if (!chatId) {
+  console.error('Missing TELEGRAM_PRIVATE_CHAT_ID');
+  process.exit(1);
+}
+
+const bot = new TelegramBot(token, { polling: false });
+
+bot
+  .createChatInviteLink(chatId, { member_limit: 1 })
+  .then((link) => console.log('Invite link:', link.invite_link))
+  .catch((err) => console.error('createChatInviteLink error:', err.message));


### PR DESCRIPTION
## Summary
- add explicit TELEGRAM_BOT_TOKEN check in telegram notifier
- improve test-telegram.js to validate env vars before creating bot

## Testing
- `npm test` *(fails: Missing script "test")*
- `node test-telegram.js`

------
https://chatgpt.com/codex/tasks/task_e_689d14d9e3348325a880b5461d0d28a2