### PR TITLE
fix(cloud-run): proper PORT handling, start script, Dockerfile; remove explicit --port flag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,5 +36,4 @@ jobs:
             --image $IMAGE \
             --region ${{ secrets.GCP_REGION }} \
             --platform managed \
-            --allow-unauthenticated \
-            --port 3000
+            --allow-unauthenticated

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,9 @@
-# ---- Build client ----
-FROM node:20-alpine AS client
+FROM node:20
 WORKDIR /app
-COPY client/package.json client/package-lock.json* client/pnpm-lock.yaml* client/yarn.lock* ./
-RUN npm install
-COPY client/ ./
-RUN npm run build
-
-# ---- Server ----
-FROM node:20-alpine AS server
-WORKDIR /app
-COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
-RUN npm install --production
-COPY src ./src
-COPY public ./public
-# Copy client build from previous stage
-COPY --from=client /app/dist/ ./public
-# runtime
+COPY package*.json ./
+RUN npm ci --omit=dev || npm install --omit=dev
+COPY . .
+RUN npm run build:client
 ENV PORT=3000
 EXPOSE 3000
-CMD ["node", "src/index.js"]
+CMD ["npm", "start"]

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "type": "module",
   "scripts": {
+    "start": "node src/index.js",
     "dev": "node src/index.js",
     "backtest": "node src/engine/backtest.js",
     "live": "node src/engine/live.js",

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import { fileURLToPath } from 'url';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import bodyParser from 'body-parser';
-import { cfg } from './config.js';
 import { db } from './storage/db.js';
 import { createSingleUseInviteLink } from './notify/telegram.js';
 import { createCheckoutSession, stripeWebhook } from './payments/stripe.js';
@@ -12,6 +11,7 @@ import { createCheckoutSession, stripeWebhook } from './payments/stripe.js';
 const app = express();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const PORT = process.env.PORT || 3000;
 
 app.use(cors());
 app.use(cookieParser());
@@ -71,4 +71,4 @@ app.get('*', (req, res) => {
     res.sendFile(path.join(__dirname, '../public/index.html'));
 });
 
-app.listen(cfg.port, () => console.log(`HTTP on :${cfg.port}`));
+app.listen(PORT, '0.0.0.0', () => console.log(`Server listening on ${PORT}`));


### PR DESCRIPTION
## Summary
- listen on env `PORT` and bind to `0.0.0.0`
- add `npm start` script for server
- simplify Dockerfile for Cloud Run and expose port 3000
- drop explicit `--port` flag from Cloud Run workflow

## Testing
- `npm start` *(fails: Missing TELEGRAM_BOT_TOKEN)*
- `docker build -q .` *(command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689dd949d9b483258b7f39eee82f0d3c