### PR TITLE
feat(data): Binance klines fetch + DB upsert

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "backtest": "node src/engine/backtest.js",
     "live": "node src/engine/live.js",
     "initdb": "node src/storage/db.js",
-    "build:client": "cd client && npm install && npm run build && cd .. && rm -rf public/* && cp -r client/dist/* public/"
+    "build:client": "cd client && npm install && npm run build && cd .. && rm -rf public/* && cp -r client/dist/* public/",
+    "fetch:binance": "node scripts/fetch-binance.js"
   },
   "dependencies": {
     "axios": "^1.7.2",

--- a/scripts/fetch-binance.js
+++ b/scripts/fetch-binance.js
@@ -1,0 +1,20 @@
+import { db, init as initDb } from '../src/storage/db.js';
+import { fetchKlines, upsertCandles } from '../src/data/binance.js';
+
+const startArg = process.argv[2] ? parseInt(process.argv[2], 10) : undefined;
+
+(async () => {
+  await initDb();
+
+  let startTime = startArg;
+  while (true) {
+    const candles = await fetchKlines({ startTime });
+    if (candles.length === 0) break;
+    await upsertCandles(db, candles);
+    console.log(`Fetched ${candles.length} candles up to ${candles[candles.length - 1].ts}`);
+    if (candles.length < 1000) break;
+    startTime = candles[candles.length - 1].ts + 1;
+  }
+
+  await db.end();
+})();

--- a/src/data/binance.js
+++ b/src/data/binance.js
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { cfg } from '../config.js';
+
+const MAX_LIMIT = 1000;
+
+export async function fetchKlines({ startTime, limit = MAX_LIMIT } = {}) {
+  const url = `${cfg.binanceBase}/api/v3/klines`;
+  const params = { symbol: cfg.symbol, interval: cfg.interval, limit };
+  if (startTime) params.startTime = startTime;
+  const { data } = await axios.get(url, { params });
+  return data.map(k => ({
+    ts: k[0],
+    open: +k[1],
+    high: +k[2],
+    low: +k[3],
+    close: +k[4],
+    volume: +k[5]
+  }));
+}
+
+export async function upsertCandles(db, candles) {
+  for (const c of candles) {
+    await db.query(
+      `INSERT INTO candles (ts, open, high, low, close, volume)
+       VALUES ($1,$2,$3,$4,$5,$6)
+       ON CONFLICT (ts) DO UPDATE SET
+         open = EXCLUDED.open,
+         high = EXCLUDED.high,
+         low = EXCLUDED.low,
+         close = EXCLUDED.close,
+         volume = EXCLUDED.volume`,
+      [c.ts, c.open, c.high, c.low, c.close, c.volume]
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add Binance data utilities for klines retrieval and DB upsert
- add script to fetch historical klines and store in DB
- expose fetch script via npm script `fetch:binance`

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f93ad19e48325a5deb08466193450