### PR TITLE
feat(bt): RSI+ATR backtest engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "backtest": "node src/engine/backtest.js",
     "live": "node src/engine/live.js",
     "initdb": "node src/storage/db.js",
-    "build:client": "cd client && npm install && npm run build && cd .. && rm -rf public/* && cp -r client/dist/* public/"
+    "build:client": "cd client && npm install && npm run build && cd .. && rm -rf public/* && cp -r client/dist/* public/",
+    "bt": "node scripts/run-backtest.js"
   },
   "dependencies": {
     "axios": "^1.7.2",

--- a/scripts/run-backtest.js
+++ b/scripts/run-backtest.js
@@ -1,0 +1,9 @@
+import fs from 'fs';
+import { runBacktest } from '../src/backtest/engine.js';
+
+const file = process.argv[2] || 'candles.json';
+const candles = JSON.parse(fs.readFileSync(file, 'utf-8'));
+
+const results = runBacktest(candles);
+console.log(results);
+

--- a/src/backtest/engine.js
+++ b/src/backtest/engine.js
@@ -1,0 +1,39 @@
+import { rsi, atr } from './indicators.js';
+
+export function runBacktest(candles, { period = 14, atrMult = 2 } = {}) {
+  let position = null;
+  let pnl = 0;
+  let trades = 0, wins = 0, losses = 0;
+
+  for (let i = period + 1; i < candles.length; i++) {
+    const slice = candles.slice(0, i + 1);
+    const closes = slice.map(c => c.close);
+    const r = rsi(closes, period);
+    const a = atr(slice, period);
+    const last = slice[slice.length - 1];
+
+    if (!position && r !== null && r < 30) {
+      const entry = last.close;
+      position = { entry, sl: entry - atrMult * a, tp: entry + atrMult * a };
+      trades++;
+    } else if (position) {
+      if (last.low <= position.sl) {
+        pnl += position.sl - position.entry;
+        losses++;
+        position = null;
+      } else if (last.high >= position.tp) {
+        pnl += position.tp - position.entry;
+        wins++;
+        position = null;
+      } else if (r !== null && r > 70) {
+        const exit = last.close;
+        pnl += exit - position.entry;
+        if (exit > position.entry) wins++; else losses++;
+        position = null;
+      }
+    }
+  }
+
+  return { trades, wins, losses, pnl };
+}
+

--- a/src/backtest/indicators.js
+++ b/src/backtest/indicators.js
@@ -1,0 +1,26 @@
+export function rsi(values, period = 14) {
+  if (values.length < period + 1) return null;
+  let gains = 0, losses = 0;
+  for (let i = values.length - period; i < values.length; i++) {
+    const diff = values[i] - values[i - 1];
+    if (diff >= 0) gains += diff; else losses -= diff;
+  }
+  const avgGain = gains / period;
+  const avgLoss = losses / period || 1e-9;
+  const rs = avgGain / avgLoss;
+  return 100 - (100 / (1 + rs));
+}
+
+export function atr(candles, period = 14) {
+  if (candles.length < period + 1) return null;
+  const trs = [];
+  for (let i = candles.length - period; i < candles.length; i++) {
+    const c = candles[i], prev = candles[i - 1];
+    const hl = c.high - c.low;
+    const hc = Math.abs(c.high - prev.close);
+    const lc = Math.abs(c.low - prev.close);
+    trs.push(Math.max(hl, hc, lc));
+  }
+  return trs.reduce((a,b)=>a+b,0) / period;
+}
+


### PR DESCRIPTION
## Summary
- add RSI and ATR indicator helpers for backtesting
- implement minimal backtest engine using RSI entries and ATR-based stops/targets
- add run-backtest script and npm `bt` shortcut

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f943ed88083259d9889a758a3bcbf