### PR TITLE
ci: add backtest smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,22 @@ jobs:
 
       - name: Compile check
         run: node -e "require('fs').accessSync('./src/index.js')"
+
+  backtest:
+    runs-on: ubuntu-latest
+    env:
+      DB_URL: ${{ secrets.DB_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install deps
+        run: npm install
+
+      - name: Backtest smoke
+        run: npm run bt -- 2024-01-01 2024-02-01


### PR DESCRIPTION
## Summary
- add backtest smoke workflow job running `npm run bt -- 2024-01-01 2024-02-01`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f94528dec832596051f870b65970c