### PR TITLE
Add grid search optimizer script

### DIFF
--- a/scripts/optimize.js
+++ b/scripts/optimize.js
@@ -1,48 +1,116 @@
 #!/usr/bin/env node
 import 'dotenv/config';
 import { Pool } from 'pg';
-import { rsi, atr } from '../src/backtest/indicators.js';
-import { runBacktest } from '../src/backtest/engine.js';
+import fs from 'fs';
+import { generateSignals } from '../src/strategy.js';
 
 const [,, start='2024-01-01', end='2024-03-01'] = process.argv;
-const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
 
-async function loadCandles(s,e){
-    const { rows } = await pool.query(
-        `SELECT ts, open, high, low, close FROM candles
-     WHERE ts >= $1::bigint AND ts < $2::bigint ORDER BY ts ASC`,
-        [Date.parse(s), Date.parse(e)]
-    );
-    return rows;
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+async function loadCandles(s, e) {
+  const startMs = Date.parse(s);
+  const endMs = Date.parse(e);
+  const { rows } = await pool.query(
+    `SELECT ts, open, high, low, close, volume
+     FROM candles
+     WHERE ts >= $1::bigint AND ts < $2::bigint
+     ORDER BY ts ASC`,
+    [startMs, endMs]
+  );
+  return rows.map(r => ({
+    ts: Number(r.ts),
+    open: Number(r.open),
+    high: Number(r.high),
+    low: Number(r.low),
+    close: Number(r.close),
+    volume: Number(r.volume),
+  }));
 }
 
-function metricScore({ pnl, maxDD }) {
-    // paprastas Sharpe-ish: PnL / (1+DD)
-    return pnl / (1 + Math.max(0, maxDD));
+function computeMetrics(trades, pnl) {
+  const closed = trades.filter(t => typeof t.pnl === 'number');
+  let eq = 0, peak = -Infinity, maxDD = 0;
+  let wins = 0;
+  for (const t of closed) {
+    eq += t.pnl;
+    if (eq > peak) peak = eq;
+    const dd = peak - eq;
+    if (dd > maxDD) maxDD = dd;
+    if (t.pnl > 0) wins++;
+  }
+  const winRate = closed.length ? (wins / closed.length) * 100 : 0;
+  const score = pnl / (1 + Math.max(0, maxDD));
+  return {
+    trades: trades.length,
+    closedTrades: closed.length,
+    winRate: Number(winRate.toFixed(2)),
+    pnl: Number(pnl.toFixed(2)),
+    maxDrawdown: Number(maxDD.toFixed(2)),
+    score: Number(score.toFixed(4)),
+  };
 }
 
-(async ()=>{
-    const rows = await loadCandles(start, end);
-    const ts=rows.map(r=>+r.ts), o=rows.map(r=>+r.open), h=rows.map(r=>+r.high), l=rows.map(r=>+r.low), c=rows.map(r=>+r.close);
-    const r14 = rsi(c,14), a14 = atr(h,l,c,14);
+(async () => {
+  const candles = await loadCandles(start, end);
+  if (candles.length < 300) {
+    console.error('Not enough candles for optimization');
+    process.exit(1);
+  }
 
-    const results = [];
-    for (const rBuy of [25,30,35]) {
-        for (const rSell of [65,70,75]) {
-            for (const mult of [1.5,2,2.5]) {
-                const { trades, pnl } = runBacktest({ ts, open:o, high:h, low:l, close:c }, { rsiArr:r14, atrArr:a14 }, { rsiBuy:rBuy, rsiSell:rSell, atrMult:mult });
-                // maxDD
-                let eq=0, peak=-Infinity, maxDD=0;
-                for (const t of trades) {
-                    if ('pnl' in t) eq += t.pnl;
-                    if (eq>peak) peak=eq;
-                    const dd=peak-eq; if (dd>maxDD) maxDD=dd;
-                }
-                results.push({ rBuy, rSell, mult, pnl:+pnl.toFixed(2), maxDD:+maxDD.toFixed(2), score:+metricScore({pnl, maxDD}).toFixed(4) });
-            }
+  const grid = {
+    rsiBuy: [25, 30, 35],
+    rsiSell: [65, 70, 75],
+    atrMult: [1.5, 2, 2.5],
+    adxMin: [12, 15, 18, 20],
+  };
+
+  const results = [];
+  for (const rBuy of grid.rsiBuy) {
+    for (const rSell of grid.rsiSell) {
+      for (const mult of grid.atrMult) {
+        for (const adxMin of grid.adxMin) {
+          const { trades, pnl } = generateSignals(candles, {
+            rsiBuy: rBuy,
+            rsiSell: rSell,
+            atrMult: mult,
+            adxMin,
+            useTrendFilter: true,
+            feePct: 0.0005,
+            slippagePct: 0.0005,
+            positionSize: 1,
+          });
+          const m = computeMetrics(trades, pnl);
+          results.push({
+            rsiBuy: rBuy,
+            rsiSell: rSell,
+            atrMult: mult,
+            adxMin,
+            ...m,
+          });
         }
+      }
     }
-    results.sort((a,b)=>b.score-a.score);
-    console.table(results.slice(0,10));
-    await pool.end();
-})();
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  console.table(results.slice(0, 15));
+
+  const headers = ['rsiBuy','rsiSell','atrMult','adxMin','trades','closedTrades','winRate','pnl','maxDrawdown','score'];
+  const csv = [
+    headers.join(','),
+    ...results.map(r => headers.map(h => r[h]).join(',')),
+  ].join('\n');
+  fs.writeFileSync('optimize.csv', csv);
+  console.log('Saved optimize.csv');
+
+  await pool.end();
+})().catch(async e => {
+  console.error(e);
+  await pool.end();
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- replace optimize script with grid-search over strategy parameters
- compute drawdown, win rate, and save CSV of results

## Testing
- `node scripts/optimize.js 2024-01-01 2024-03-01` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bfc440788325abf58fa20fcae597