### PR TITLE
Add walkforward summary script and visualization

### DIFF
--- a/client/src/pages/Backtests.jsx
+++ b/client/src/pages/Backtests.jsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+
+export default function Backtests() {
+  const [summary, setSummary] = useState(null);
+  const [rows, setRows] = useState([]);
+
+  useEffect(() => {
+    fetch('/walkforward-summary.json').then(r=>r.ok?r.json():null).then(setSummary).catch(()=>{});
+    fetch('/walkforward.csv')
+      .then(r=>r.text())
+      .then(t => {
+        const lines = t.trim().split('\n');
+        const header = lines.shift().split(',');
+        const idx = Object.fromEntries(header.map((h,i)=>[h,i]));
+        const out = lines.map(line => {
+          const c = line.split(',');
+          return {
+            trainStart: c[idx.trainStart],
+            trainEnd: c[idx.trainEnd],
+            testStart: c[idx.testStart],
+            testEnd: c[idx.testEnd],
+            rsiBuy: c[idx.rsiBuy],
+            rsiSell: c[idx.rsiSell],
+            atrMult: c[idx.atrMult],
+            adxMin: c[idx.adxMin],
+            trades: c[idx.trades],
+            closedTrades: c[idx.closedTrades],
+            winRate: c[idx.winRate],
+            pnl: c[idx.pnl],
+            maxDrawdown: c[idx.maxDrawdown],
+            score: c[idx.score],
+          };
+        });
+        setRows(out);
+      })
+      .catch(()=>{});
+  }, []);
+
+  return (
+    <div style={{padding:'16px', maxWidth: 1200, margin: '0 auto', fontFamily:'system-ui, Arial'}}>
+      <h1>Backtests</h1>
+
+      {summary && (
+        <div style={{display:'grid', gridTemplateColumns:'repeat(4, 1fr)', gap:12, margin:'12px 0'}}>
+          <Card title="Folds" value={summary.folds}/>
+          <Card title="Avg PnL" value={summary.avgPnL}/>
+          <Card title="Avg WinRate (%)" value={summary.avgWinRate}/>
+          <Card title="Avg MaxDD" value={summary.avgMaxDD}/>
+        </div>
+      )}
+
+      <div style={{margin:'12px 0'}}>
+        <a href="/wf.html" target="_blank" rel="noreferrer">
+          <button style={{padding:'8px 12px'}}>Atidaryti grafikus</button>
+        </a>
+      </div>
+
+      <div style={{overflowX:'auto'}}>
+        <table cellPadding="6" cellSpacing="0" style={{borderCollapse:'collapse', width:'100%'}}>
+          <thead>
+            <tr>
+              {['trainStart','trainEnd','testStart','testEnd','rsiBuy','rsiSell','atrMult','adxMin','trades','closedTrades','winRate','pnl','maxDrawdown','score'].map(h=>(
+                <th key={h} style={{borderBottom:'1px solid #ddd', textAlign:'left'}}>{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r,i)=>(
+              <tr key={i} style={{borderBottom:'1px solid #f0f0f0'}}>
+                <td>{r.trainStart}</td><td>{r.trainEnd}</td><td>{r.testStart}</td><td>{r.testEnd}</td>
+                <td>{r.rsiBuy}</td><td>{r.rsiSell}</td><td>{r.atrMult}</td><td>{r.adxMin}</td>
+                <td>{r.trades}</td><td>{r.closedTrades}</td><td>{r.winRate}</td><td>{r.pnl}</td><td>{r.maxDrawdown}</td><td>{r.score}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function Card({title, value}) {
+  return (
+    <div style={{padding:12, border:'1px solid #eee', borderRadius:8, boxShadow:'0 1px 2px rgba(0,0,0,0.04)'}}>
+      <div style={{fontSize:12, color:'#666'}}>{title}</div>
+      <div style={{fontSize:20, fontWeight:700}}>{value}</div>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "fetch:binance": "node scripts/fetch-binance.js",
     "opt": "node scripts/optimize.js",
     "signals": "node scripts/generate-signals.js",
-    "wf": "node scripts/walkforward.js"
+    "wf": "node scripts/walkforward.js",
+    "wf:summary": "node scripts/wf-summary.js"
   },
   "dependencies": {
     "axios": "^1.7.2",

--- a/public/wf.html
+++ b/public/wf.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Walk-Forward Charts</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <style>
+    body { font-family: system-ui, Arial, sans-serif; margin: 20px; }
+    .chart { margin: 24px 0; }
+    h2 { margin-bottom: 8px; }
+    svg { width: 100%; height: 320px; }
+    .axis path, .axis line { stroke: #999; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+</head>
+<body>
+  <h1>Walk-Forward Results</h1>
+
+  <div class="chart">
+    <h2>Fold PnL (bars)</h2>
+    <svg id="bars"></svg>
+  </div>
+
+  <div class="chart">
+    <h2>Aggregated Equity (line)</h2>
+    <svg id="line"></svg>
+  </div>
+
+  <script>
+    async function parseCSV(text) {
+      const rows = text.trim().split('\n').map(r => r.split(','));
+      const header = rows.shift();
+      return rows.map(cols => Object.fromEntries(header.map((h,i)=>[h, cols[i]])));
+    }
+
+    function drawBars(data) {
+      const svg = d3.select('#bars');
+      svg.selectAll('*').remove();
+      const w = svg.node().clientWidth, h = svg.node().clientHeight;
+      const margin = {top:20,right:20,bottom:30,left:50};
+      const innerW = w - margin.left - margin.right;
+      const innerH = h - margin.top - margin.bottom;
+
+      const x = d3.scaleBand().domain(d3.range(data.length)).range([0, innerW]).padding(0.2);
+      const y = d3.scaleLinear().domain([d3.min(data, d=>d.pnl), d3.max(data, d=>d.pnl)]).nice().range([innerH, 0]);
+
+      const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+      g.append('g').attr('transform', `translate(0,${innerH})`).call(d3.axisBottom(x).tickFormat(i=>i+1));
+      g.append('g').call(d3.axisLeft(y));
+
+      g.selectAll('rect').data(data).enter().append('rect')
+        .attr('x', (_,i) => x(i))
+        .attr('y', d => y(Math.max(0,d.pnl)))
+        .attr('width', x.bandwidth())
+        .attr('height', d => Math.abs(y(d.pnl) - y(0)))
+        .attr('fill', d => d.pnl >= 0 ? '#4caf50' : '#f44336')
+        .append('title').text(d => `Fold ${d.idx}: PnL ${d.pnl.toFixed(2)}`);
+    }
+
+    function drawLine(data) {
+      const svg = d3.select('#line');
+      svg.selectAll('*').remove();
+      const w = svg.node().clientWidth, h = svg.node().clientHeight;
+      const margin = {top:20,right:20,bottom:30,left:50};
+      const innerW = w - margin.left - margin.right;
+      const innerH = h - margin.top - margin.bottom;
+
+      const x = d3.scaleLinear().domain([1, d3.max(data, d=>d.idx)]).range([0, innerW]);
+      const y = d3.scaleLinear().domain(d3.extent(data, d=>d.equity)).nice().range([innerH, 0]);
+
+      const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+      g.append('g').attr('transform', `translate(0,${innerH})`).call(d3.axisBottom(x).ticks(8));
+      g.append('g').call(d3.axisLeft(y));
+
+      const line = d3.line().x(d=>x(d.idx)).y(d=>y(d.equity));
+      g.append('path')
+        .datum(data)
+        .attr('fill','none')
+        .attr('stroke','#2196f3')
+        .attr('stroke-width',2)
+        .attr('d', line);
+    }
+
+    async function main() {
+      // bars from walkforward.csv
+      const csv1 = await fetch('./walkforward.csv').then(r=>r.text());
+      const rows1 = await parseCSV(csv1);
+      const pnlRows = rows1.map((r, i) => ({ idx: i+1, pnl: +r.pnl || 0 }));
+      drawBars(pnlRows);
+
+      // aggregated line from walkforward-agg.csv
+      const csv2 = await fetch('./walkforward-agg.csv').then(r=>r.text());
+      const rows2 = await parseCSV(csv2);
+      const lineRows = rows2.map(r => ({ idx: +r.idx, equity: +r.equity }));
+      drawLine(lineRows);
+    }
+    main();
+  </script>
+</body>
+</html>

--- a/scripts/wf-summary.js
+++ b/scripts/wf-summary.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import fs from 'fs';
+
+const CSV = 'walkforward.csv';
+const OUT_JSON = 'walkforward-summary.json';
+const OUT_AGG = 'walkforward-agg.csv';
+
+if (!fs.existsSync(CSV)) {
+  console.error(`${CSV} nerastas. Pirmiau paleisk: node scripts/walkforward.js ...`);
+  process.exit(1);
+}
+
+const lines = fs.readFileSync(CSV, 'utf-8').trim().split('\n');
+if (lines.length < 2) {
+  console.error('walkforward.csv tuščias.');
+  process.exit(1);
+}
+const header = lines[0].split(',');
+const idx = Object.fromEntries(header.map((h,i)=>[h,i]));
+const rows = lines.slice(1).map(line => line.split(','));
+
+let folds = 0, sumPnL = 0, sumWR = 0, sumDD = 0;
+const pnlSeq = [];
+
+for (const r of rows) {
+  const pnl = Number(r[idx['pnl']] ?? 0);
+  const wr = Number(r[idx['winRate']] ?? 0);
+  const dd = Number(r[idx['maxDrawdown']] ?? 0);
+  sumPnL += pnl; sumWR += wr; sumDD += dd; folds++;
+  pnlSeq.push(pnl);
+}
+
+const summary = {
+  folds,
+  avgPnL: Number((sumPnL / folds).toFixed(2)),
+  avgWinRate: Number((sumWR / folds).toFixed(2)),
+  avgMaxDD: Number((sumDD / folds).toFixed(2)),
+};
+
+fs.writeFileSync(OUT_JSON, JSON.stringify(summary, null, 2));
+
+// aggregated equity per fold
+let eq = 0;
+const aggLines = ['idx,equity'];
+for (let i = 0; i < pnlSeq.length; i++) {
+  eq += pnlSeq[i];
+  aggLines.push(`${i+1},${eq.toFixed(2)}`);
+}
+fs.writeFileSync(OUT_AGG, aggLines.join('\n'));
+
+console.log('WF summary:', summary);
+console.log(`Saved ${OUT_JSON}, ${OUT_AGG}`);


### PR DESCRIPTION
## Summary
- add `scripts/wf-summary.js` to aggregate walkforward metrics and equity
- create `public/wf.html` for D3 bar/line charts of fold PnL and equity
- add Backtests page that loads summary and table with link to charts
- expose `wf:summary` npm script

## Testing
- `node scripts/wf-summary.js`
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a2feaac1b08325b698b9bd5278d413