### PR TITLE
Add SPA routing with backtests page

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,9 +9,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@stripe/stripe-js": "^3.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@stripe/stripe-js": "^3.4.1"
+    "react-router-dom": "^6.26.1"
   },
   "devDependencies": {
     "vite": "^5.4.0",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,84 +1,26 @@
-import React, { useState } from 'react'
-import { loadStripe } from '@stripe/stripe-js'
-const stripePromise = loadStripe('pk_test_placeholder') // replaced by Stripe when you deploy via env + proxy if needed
+import { Link, Routes, Route, Navigate } from 'react-router-dom';
+import Home from './pages/Home.jsx';
+import Backtests from './pages/Backtests.jsx';
 
-export default function App(){
-  const [loading, setLoading] = useState(false)
-  const url = new URL(window.location.href)
-  const isSuccess = !!url.searchParams.get('success')
-  const isCanceled = !!url.searchParams.get('canceled')
-  const [status, setStatus] = useState(isSuccess ? 'Success! Thank you for subscribing.' : (isCanceled ? 'Payment canceled.' : ''))
-  const [email, setEmail] = useState('')
-  const [invite, setInvite] = useState(null)
-
-  async function subscribe(){
-    try{
-      setLoading(true)
-      const res = await fetch('/api/checkout-session', { method: 'POST' })
-      const j = await res.json()
-      if (j.url) window.location.href = j.url
-      else setStatus('Failed to create checkout session.')
-    }catch(e){
-      console.error(e); setStatus('Network error.')
-    }finally{
-      setLoading(false)
-    }
-  }
-
-  async function getInvite(){
-    try{
-      setLoading(true)
-      const q = new URLSearchParams({ email })
-      const res = await fetch(`/api/telegram-invite?${q.toString()}`)
-      const j = await res.json()
-      if (j.invite) {
-        setInvite(j.invite)
-        setStatus('Invite generated. Click the link below to join.')
-      } else {
-        setStatus(j.error || 'Invite failed')
-      }
-    }catch(e){
-      console.error(e); setStatus('Network error.')
-    }finally{
-      setLoading(false)
-    }
-  }
-
+export default function App() {
   return (
-      <div style={{fontFamily:'Inter, system-ui, Arial', padding:'2rem', maxWidth:900, margin:'0 auto'}}>
+    <div style={{fontFamily:'system-ui, Arial', minHeight:'100vh'}}>
+      <header style={{
+        display:'flex', alignItems:'center', gap:16,
+        padding:'12px 16px', borderBottom:'1px solid #eee'
+      }}>
+        <Link to="/" style={{fontWeight:700, textDecoration:'none'}}>Home</Link>
+        <Link to="/backtests" style={{textDecoration:'none'}}>Backtests</Link>
+      </header>
 
-        {/* Header ir Hero kaip buvo */}
-
-        <section style={{marginTop:'2rem', padding:'1.5rem', border:'1px solid #eee', borderRadius:12}}>
-          <h3>Pricing</h3>
-          <p><strong>€20/month</strong> – access to private Telegram signals (full details, TP/SL)</p>
-          <button onClick={subscribe} disabled={loading} style={{padding:'0.8rem 1.2rem', borderRadius:10, border:'none', cursor:'pointer'}}>
-            {loading ? 'Redirecting…' : 'Subscribe with Stripe'}
-          </button>
-          {status && <p style={{marginTop:'1rem'}}>{status}</p>}
-
-          {isSuccess && (
-              <div style={{marginTop:'1rem'}}>
-                <h4>Join private Telegram</h4>
-                <p>Enter the same email you used at checkout to get a one-time invite link.</p>
-                <div style={{display:'flex', gap:8}}>
-                  <input value={email} onChange={e=>setEmail(e.target.value)} placeholder="your@email"
-                         style={{flex:1, padding:'0.6rem', border:'1px solid #ddd', borderRadius:8}} />
-                  <button onClick={getInvite} disabled={loading || !email}
-                          style={{padding:'0.6rem 1rem', borderRadius:8, border:'none', cursor:'pointer'}}>
-                    {loading ? 'Generating…' : 'Get Invite'}
-                  </button>
-                </div>
-                {invite && (
-                    <p style={{marginTop:'0.8rem'}}>
-                      <a href={invite} target="_blank" rel="noreferrer">Click to join private channel →</a>
-                    </p>
-                )}
-              </div>
-          )}
-        </section>
-
-        <footer style={{marginTop:'3rem', color:'#777'}}>© {new Date().getFullYear()} Crypto Signals MVP</footer>
-      </div>
-  )
+      <main style={{padding:'16px'}}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/backtests" element={<Backtests />} />
+          {/* Bet koks nežinomas kelias -> į Home (arba gali nukreipti į /backtests) */}
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </main>
+    </div>
+  );
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,5 +1,12 @@
-import React from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App.jsx'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
 
-createRoot(document.getElementById('root')).render(<App />)
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import { loadStripe } from '@stripe/stripe-js';
+const stripePromise = loadStripe('pk_test_placeholder'); // replaced by Stripe when you deploy via env + proxy if needed
+
+export default function Home(){
+  const [loading, setLoading] = useState(false);
+  const url = new URL(window.location.href);
+  const isSuccess = !!url.searchParams.get('success');
+  const isCanceled = !!url.searchParams.get('canceled');
+  const [status, setStatus] = useState(isSuccess ? 'Success! Thank you for subscribing.' : (isCanceled ? 'Payment canceled.' : ''));
+  const [email, setEmail] = useState('');
+  const [invite, setInvite] = useState(null);
+
+  async function subscribe(){
+    try{
+      setLoading(true);
+      const res = await fetch('/api/checkout-session', { method: 'POST' });
+      const j = await res.json();
+      if (j.url) window.location.href = j.url;
+      else setStatus('Failed to create checkout session.');
+    }catch(e){
+      console.error(e); setStatus('Network error.');
+    }finally{
+      setLoading(false);
+    }
+  }
+
+  async function getInvite(){
+    try{
+      setLoading(true);
+      const q = new URLSearchParams({ email });
+      const res = await fetch(`/api/telegram-invite?${q.toString()}`);
+      const j = await res.json();
+      if (j.invite) {
+        setInvite(j.invite);
+        setStatus('Invite generated. Click the link below to join.');
+      } else {
+        setStatus(j.error || 'Invite failed');
+      }
+    }catch(e){
+      console.error(e); setStatus('Network error.');
+    }finally{
+      setLoading(false);
+    }
+  }
+
+  return (
+      <div style={{fontFamily:'Inter, system-ui, Arial', padding:'2rem', maxWidth:900, margin:'0 auto'}}>
+
+        {/* Header ir Hero kaip buvo */}
+
+        <section style={{marginTop:'2rem', padding:'1.5rem', border:'1px solid #eee', borderRadius:12}}>
+          <h3>Pricing</h3>
+          <p><strong>€20/month</strong> – access to private Telegram signals (full details, TP/SL)</p>
+          <button onClick={subscribe} disabled={loading} style={{padding:'0.8rem 1.2rem', borderRadius:10, border:'none', cursor:'pointer'}}>
+            {loading ? 'Redirecting…' : 'Subscribe with Stripe'}
+          </button>
+          {status && <p style={{marginTop:'1rem'}}>{status}</p>}
+
+          {isSuccess && (
+              <div style={{marginTop:'1rem'}}>
+                <h4>Join private Telegram</h4>
+                <p>Enter the same email you used at checkout to get a one-time invite link.</p>
+                <div style={{display:'flex', gap:8}}>
+                  <input value={email} onChange={e=>setEmail(e.target.value)} placeholder="your@email"
+                         style={{flex:1, padding:'0.6rem', border:'1px solid #ddd', borderRadius:8}} />
+                  <button onClick={getInvite} disabled={loading || !email}
+                          style={{padding:'0.6rem 1rem', borderRadius:8, border:'none', cursor:'pointer'}}>
+                    {loading ? 'Generating…' : 'Get Invite'}
+                  </button>
+                </div>
+                {invite && (
+                    <p style={{marginTop:'0.8rem'}}>
+                      <a href={invite} target="_blank" rel="noreferrer">Click to join private channel →</a>
+                    </p>
+                )}
+              </div>
+          )}
+        </section>
+
+        <footer style={{marginTop:'3rem', color:'#777'}}>© {new Date().getFullYear()} Crypto Signals MVP</footer>
+      </div>
+  )
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,8 @@ import { db } from './storage/db.js';
 import { createSingleUseInviteLink } from './notify/telegram.js';
 import { createCheckoutSession, stripeWebhook } from './payments/stripe.js';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const PORT = process.env.PORT || 3000;
 
 app.use(cors());
 app.use(cookieParser());
@@ -65,10 +63,15 @@ app.get('/api/telegram-invite', async (req, res) => {
   }
 });
 
-// Serve static (React build copied to /public)
-app.use(express.static(path.join(__dirname, '../public')));
+// Static files
+app.use(express.static(path.join(__dirname, '..', 'public')));
+
+// SPA fallback — bet koks kitas GET, kuris nepateko į API/static, grąžina index.html
 app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, '../public/index.html'));
+  res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
 });
 
-app.listen(PORT, '0.0.0.0', () => console.log(`Server listening on ${PORT}`));
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on :${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add react-router-dom and wrap app with BrowserRouter
- add nav links and routes for Home and Backtests pages
- serve index.html for unknown routes in Express for SPA fallback

## Testing
- `npm install`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a36e5c76a88325967799b2c7e7b3c3