### PR TITLE
feat: add equity analytics and optimization charts

### DIFF
--- a/client/public/analytics.html
+++ b/client/public/analytics.html
@@ -5,23 +5,27 @@
   <title>Analytics</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; margin: 24px; color: #111; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; margin: 24px; color: #111; background:#fafafa; }
     h1 { margin-bottom: 8px; }
-    .grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(260px,1fr)); gap: 16px; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(280px,1fr)); gap: 16px; }
     .card { border: 1px solid #e5e7eb; border-radius: 12px; padding: 16px; background: #fff; }
     .muted { color: #6b7280; font-size: 12px; }
-    table { border-collapse: collapse; width: 100%; }
+    table { border-collapse: collapse; width: 100%; background:#fff }
     th, td { border-bottom: 1px solid #eee; padding: 8px; text-align: right; }
     th { text-align: right; color: #374151; font-weight: 600; }
     td:first-child, th:first-child { text-align: left; }
     .kpis { font-size: 28px; font-weight: 700; }
     .section { margin-top: 24px; }
-    code { background: #f3f4f6; padding: 2px 6px; border-radius: 6px; }
+    .controls { display:flex; gap:8px; align-items:center; margin-bottom:8px; }
+    select { padding:6px 8px; border:1px solid #ddd; border-radius:8px; background:#fff; }
+    canvas { background:#fff; border:1px solid #eee; border-radius:12px; padding:8px; }
   </style>
+  <!-- Chart.js per CDN -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
 </head>
 <body>
   <h1>Analytics</h1>
-  <p class="muted">/analytics API santrauka (Backtest, Optimize, Walkforward)</p>
+  <p class="muted">/analytics + /analytics/equity + /analytics/optimize</p>
 
   <div class="grid">
     <div class="card">
@@ -36,8 +40,40 @@
     </div>
   </div>
 
+  <div class="section grid">
+    <div class="card">
+      <h3 style="margin:0 0 8px 0;">Backtest Equity</h3>
+      <canvas id="chart-backtest" height="180"></canvas>
+    </div>
+    <div class="card">
+      <h3 style="margin:0 0 8px 0;">Walkforward Aggregated Equity</h3>
+      <canvas id="chart-wf" height="180"></canvas>
+    </div>
+  </div>
+
   <div class="section card">
-    <h3 style="margin:0 0 8px 0;">Optimize – Top 50</h3>
+    <div class="controls">
+      <h3 style="margin:0;">Optimize – Top</h3>
+      <select id="opt-limit">
+        <option>10</option>
+        <option>25</option>
+        <option selected>50</option>
+        <option>100</option>
+      </select>
+      <span class="muted">sort by</span>
+      <select id="opt-sort">
+        <option value="score" selected>score</option>
+        <option value="pnl">pnl</option>
+        <option value="winRate">winRate</option>
+        <option value="maxDrawdown">maxDrawdown</option>
+        <option value="trades">trades</option>
+      </select>
+      <select id="opt-dir">
+        <option value="desc" selected>desc</option>
+        <option value="asc">asc</option>
+      </select>
+      <button id="opt-refresh" style="margin-left:auto; padding:6px 10px; border:1px solid #ddd; border-radius:8px; background:#fff; cursor:pointer;">Reload</button>
+    </div>
     <div class="muted">Iš <code>optimize.csv</code></div>
     <div style="overflow:auto;">
       <table id="opt-table">
@@ -53,49 +89,112 @@
   </div>
 
   <script>
-    async function load() {
-      try {
-        const res = await fetch('/analytics');
-        const data = await res.json();
+    let chartsReady = false;
+    let chartBT = null, chartWF = null;
 
-        const bt = data.backtest || {};
-        const wf = data.walkforward || {};
-        const opt = Array.isArray(data.optimize) ? data.optimize : [];
+    function num(v) { return Number.isFinite(+v) ? (+v).toFixed(2) : '0.00'; }
+    function pct(v) { return Number.isFinite(+v) ? (+v).toFixed(2) + '%' : '0.00%'; }
 
-        // Backtest KPI
-        document.getElementById('bt-pnl').textContent = num(bt.pnl);
-        document.getElementById('bt-win').textContent = pct(bt.winRate);
-        document.getElementById('bt-dd').textContent  = num(bt.maxDrawdown);
+    async function loadAnalytics() {
+      const r = await fetch('/analytics');
+      return r.json();
+    }
+    async function loadEquity() {
+      const r = await fetch('/analytics/equity');
+      return r.json();
+    }
+    async function loadOptimize(limit=50, sort='score', dir='desc') {
+      const r = await fetch(`/analytics/optimize?limit=${encodeURIComponent(limit)}&sort=${encodeURIComponent(sort)}&dir=${encodeURIComponent(dir)}`);
+      return r.json();
+    }
 
-        // Walkforward KPI
-        document.getElementById('wf-pnl').textContent   = num(wf.pnl);
-        document.getElementById('wf-win').textContent   = pct(wf.winRate);
-        document.getElementById('wf-dd').textContent    = num(wf.maxDrawdown);
-        document.getElementById('wf-folds').textContent = wf.folds ?? '–';
+    function renderKPI(data) {
+      const bt = data.backtest || {};
+      const wf = data.walkforward || {};
+      document.getElementById('bt-pnl').textContent = num(bt.pnl);
+      document.getElementById('bt-win').textContent = pct(bt.winRate);
+      document.getElementById('bt-dd').textContent  = num(bt.maxDrawdown);
+      document.getElementById('wf-pnl').textContent = num(wf.pnl);
+      document.getElementById('wf-win').textContent = pct(wf.winRate);
+      document.getElementById('wf-dd').textContent  = num(wf.maxDrawdown);
+      document.getElementById('wf-folds').textContent = wf.folds ?? '–';
+    }
 
-        // Optimize table
-        const tbody = document.querySelector('#opt-table tbody');
-        tbody.innerHTML = '';
-        for (const r of opt) {
-          const tr = document.createElement('tr');
-          tr.innerHTML = [
-            r.rsiBuy, r.rsiSell, r.atrMult, r.adxMin,
-            r.trades, r.closedTrades,
-            fix2(r.winRate), fix2(r.pnl), fix2(r.maxDrawdown), fix4(r.score)
-          ].map(c => `<td>${c ?? 0}</td>`).join('');
-          tbody.appendChild(tr);
-        }
-      } catch (e) {
-        console.error('analytics.html load error', e);
+    function ensureCharts() {
+      if (chartsReady) return;
+      const ctxBT = document.getElementById('chart-backtest').getContext('2d');
+      const ctxWF = document.getElementById('chart-wf').getContext('2d');
+      chartBT = new Chart(ctxBT, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Equity', data: [], tension: 0.2, pointRadius: 0 }] },
+        options: { responsive: true, scales: { x: { ticks: { maxTicksLimit: 6 } }, y: { beginAtZero: false } } }
+      });
+      chartWF = new Chart(ctxWF, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Aggregated Equity', data: [], tension: 0.2, pointRadius: 0 }] },
+        options: { responsive: true, scales: { x: { ticks: { maxTicksLimit: 6 } }, y: { beginAtZero: false } } }
+      });
+      chartsReady = true;
+    }
+
+    function renderBacktestChart(points) {
+      if (!chartBT) return;
+      const labels = points.map(p => new Date(p.ts).toLocaleDateString());
+      const data   = points.map(p => +p.equity || 0);
+      chartBT.data.labels = labels;
+      chartBT.data.datasets[0].data = data;
+      chartBT.update();
+    }
+    function renderWFChart(points) {
+      if (!chartWF) return;
+      const labels = points.map(p => p.idx);
+      const data   = points.map(p => +p.equity || 0);
+      chartWF.data.labels = labels;
+      chartWF.data.datasets[0].data = data;
+      chartWF.update();
+    }
+
+    async function renderOptimize(limit=50, sort='score', dir='desc') {
+      const rows = await loadOptimize(limit, sort, dir);
+      const tbody = document.querySelector('#opt-table tbody');
+      tbody.innerHTML = '';
+      for (const r of rows) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = [
+          r.rsiBuy, r.rsiSell, r.atrMult, r.adxMin,
+          r.trades, r.closedTrades,
+          num(r.winRate), num(r.pnl), num(r.maxDrawdown), (+r.score || 0).toFixed(4)
+        ].map(c => `<td>${c ?? 0}</td>`).join('');
+        tbody.appendChild(tr);
       }
     }
 
-    const fix2 = v => (Number.isFinite(+v) ? (+v).toFixed(2) : '0.00');
-    const fix4 = v => (Number.isFinite(+v) ? (+v).toFixed(4) : '0.0000');
-    const num  = v => Number.isFinite(+v) ? (+v).toFixed(2) : '0.00';
-    const pct  = v => Number.isFinite(+v) ? `${(+v).toFixed(2)}%` : '0.00%';
+    async function init() {
+      ensureCharts();
 
-    load();
+      const analytics = await loadAnalytics();
+      renderKPI(analytics);
+
+      const equity = await loadEquity();
+      renderBacktestChart(Array.isArray(equity.backtest) ? equity.backtest : []);
+      renderWFChart(Array.isArray(equity.walkforward) ? equity.walkforward : []);
+
+      const limitSel = document.getElementById('opt-limit');
+      const sortSel  = document.getElementById('opt-sort');
+      const dirSel   = document.getElementById('opt-dir');
+      const btn      = document.getElementById('opt-refresh');
+
+      const reload = () => renderOptimize(parseInt(limitSel.value,10), sortSel.value, dirSel.value);
+      btn.addEventListener('click', reload);
+
+      // initial load
+      reload();
+    }
+
+    window.addEventListener('load', () => {
+      if (window.Chart) init();
+      else console.error('Chart.js failed to load');
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add /analytics/equity endpoint serving backtest and walkforward series
- add /analytics/optimize endpoint with sorting and limiting
- overhaul analytics.html with Chart.js graphs and optimize table controls

## Testing
- `npm run build:client`
- `node --check src/index.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4bbdf28b88325888610d97779c3cf