### PR TITLE
chore: add nightly analytics deploy workflow

### DIFF
--- a/.github/workflows/analytics-cron.yml
+++ b/.github/workflows/analytics-cron.yml
@@ -1,0 +1,91 @@
+name: Nightly Analytics + Deploy
+
+on:
+  schedule:
+    # Kasnakt 02:30 Vilnius laiku (Europe/Vilnius = UTC+2/3). Cron naudoja UTC -> 23:30 UTC ~ 02:30 LT (vasara)
+    - cron: '30 23 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  analytics-deploy:
+    runs-on: ubuntu-latest
+    env:
+      TZ: Europe/Vilnius
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      STRIPE_SECRET: ${{ secrets.STRIPE_SECRET }}
+      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      GCP_REGION: ${{ secrets.GCP_REGION }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install deps (root + client)
+        run: |
+          npm ci
+          cd client && npm ci
+
+      - name: Compute date range (last 180 days)
+        id: dates
+        run: |
+          NOW=$(date -u +%Y-%m-%d)
+          START=$(date -u -d "180 days ago" +%Y-%m-%d)
+          echo "start=$START" >> $GITHUB_OUTPUT
+          echo "end=$NOW" >> $GITHUB_OUTPUT
+          echo "Using range: $START .. $NOW"
+
+      # 1) Backtest -> client/public/backtest.csv, metrics.json
+      - name: Backtest
+        run: |
+          node scripts/run-backtest.js "${{ steps.dates.outputs.start }}" "${{ steps.dates.outputs.end }}"
+
+      # 2) Optimize -> client/public/optimize.csv
+      - name: Optimize
+        run: |
+          node scripts/optimize.js "${{ steps.dates.outputs.start }}" "${{ steps.dates.outputs.end }}"
+
+      # 3) Walkforward -> client/public/walkforward-agg.csv, walkforward-summary.json
+      - name: Walkforward (train=60d, test=30d)
+        run: |
+          node scripts/walkforward.js "${{ steps.dates.outputs.start }}" "${{ steps.dates.outputs.end }}" --train 60 --test 30
+
+      # 4) Build client (išsaugant wf.html ir analytics.html)
+      - name: Build client
+        run: |
+          npm run build:client
+
+      # 5) Google Cloud auth + Docker push + Cloud Run deploy
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
+
+      - name: Build & Push Docker image
+        run: |
+          IMAGE="${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/crypto-signal/crypto-signals:latest"
+          docker build -t "$IMAGE" .
+          docker push "$IMAGE"
+
+      - name: Deploy to Cloud Run
+        run: |
+          IMAGE="${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/crypto-signal/crypto-signals:latest"
+          gcloud run deploy crypto-signals-prod \
+            --image "$IMAGE" \
+            --region "${{ env.GCP_REGION }}" \
+            --platform managed \
+            --allow-unauthenticated \
+            --set-env-vars "DATABASE_URL=${{ secrets.DATABASE_URL }},TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }},STRIPE_SECRET=${{ secrets.STRIPE_SECRET }},STRIPE_WEBHOOK_SECRET=${{ secrets.STRIPE_WEBHOOK_SECRET }}"
+


### PR DESCRIPTION
## Summary
- add nightly analytics workflow to run backtests, optimization, walkforward, build client, and deploy to Cloud Run

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4dd1eff808325a8430ae123618b15