### PR TITLE
Add health, version and download endpoints with health page

### DIFF
--- a/.github/workflows/analytics-cron.yml
+++ b/.github/workflows/analytics-cron.yml
@@ -82,10 +82,11 @@ jobs:
       - name: Deploy to Cloud Run
         run: |
           IMAGE="${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/crypto-signal/crypto-signals:latest"
+          BUILD_TIME="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           gcloud run deploy crypto-signals-prod \
             --image "$IMAGE" \
             --region "${{ env.GCP_REGION }}" \
             --platform managed \
             --allow-unauthenticated \
-            --set-env-vars "DATABASE_URL=${{ secrets.DATABASE_URL }},TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }},STRIPE_SECRET=${{ secrets.STRIPE_SECRET }},STRIPE_WEBHOOK_SECRET=${{ secrets.STRIPE_WEBHOOK_SECRET }}"
+            --set-env-vars "DATABASE_URL=${{ secrets.DATABASE_URL }},TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }},STRIPE_SECRET=${{ secrets.STRIPE_SECRET }},STRIPE_WEBHOOK_SECRET=${{ secrets.STRIPE_WEBHOOK_SECRET }},GIT_SHA=$GITHUB_SHA,BUILD_TIME=$BUILD_TIME"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,6 +51,7 @@ jobs:
           TELEGRAM_PRIVATE_CHAT_ID: ${{ secrets.TELEGRAM_PRIVATE_CHAT_ID }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}                         # Neon: ...?sslmode=require
         run: |
+          BUILD_TIME="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           gcloud run deploy "$SERVICE" \
             --project "$PROJECT_ID" \
             --region "$REGION" \
@@ -64,6 +65,8 @@ jobs:
             --set-env-vars "TELEGRAM_BOT_TOKEN=$TELEGRAM_BOT_TOKEN" \
             --set-env-vars "TELEGRAM_PRIVATE_CHAT_ID=$TELEGRAM_PRIVATE_CHAT_ID" \
             --set-env-vars "DATABASE_URL=$DATABASE_URL" \
+            --set-env-vars "GIT_SHA=$GITHUB_SHA" \
+            --set-env-vars "BUILD_TIME=$BUILD_TIME" \
             --concurrency=80 \
             --cpu=1 --memory=512Mi \
             --min-instances=0 --max-instances=5

--- a/client/public/health.html
+++ b/client/public/health.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="lt">
+<head>
+  <meta charset="utf-8" />
+  <title>Health</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; margin: 24px; color: #111; background:#fafafa; }
+    .card { border:1px solid #e5e7eb; border-radius:12px; padding:16px; background:#fff; max-width:720px; }
+    .row { display:flex; align-items:center; gap:8px; }
+    .dot { width:10px; height:10px; border-radius:50%; display:inline-block; }
+    .ok { background:#10b981; }
+    .bad { background:#ef4444; }
+    table { border-collapse: collapse; width:100%; margin-top:12px; }
+    th, td { border-bottom:1px solid #eee; padding:8px; text-align:left; }
+    th { color:#374151; }
+    code { background:#f3f4f6; padding:2px 4px; border-radius:6px; }
+  </style>
+</head>
+<body>
+  <h1>Service Health</h1>
+  <div class="card">
+    <div id="status" class="row"><span class="dot"></span><strong>Loading…</strong></div>
+    <div id="meta" style="margin-top:8px;" class="muted"></div>
+
+    <table id="env">
+      <thead><tr><th>Env</th><th>Present</th></tr></thead>
+      <tbody></tbody>
+    </table>
+
+    <table id="sys">
+      <thead><tr><th>Key</th><th>Value</th></tr></thead>
+      <tbody></tbody>
+    </table>
+
+    <div style="margin-top:8px;">
+      Parsisiųsti CSV/JSON:
+      <a href="/download/backtest.csv">backtest.csv</a> ·
+      <a href="/download/optimize.csv">optimize.csv</a> ·
+      <a href="/download/walkforward-agg.csv">walkforward-agg.csv</a> ·
+      <a href="/download/walkforward-summary.json">walkforward-summary.json</a> ·
+      <a href="/download/metrics.json">metrics.json</a>
+    </div>
+  </div>
+
+  <script>
+    async function init() {
+      const h = await fetch('/health').then(r=>r.json()).catch(()=>null);
+      const v = await fetch('/version').then(r=>r.json()).catch(()=>null);
+
+      const status = document.getElementById('status');
+      const dot = status.querySelector('.dot');
+      const text = status.querySelector('strong');
+
+      if (!h) {
+        dot.className = 'dot bad';
+        text.textContent = 'offline';
+        return;
+      }
+      const ok = h.status === 'ok';
+      dot.className = 'dot ' + (ok ? 'ok' : 'bad');
+      text.textContent = ok ? 'ok' : 'degraded';
+
+      const meta = document.getElementById('meta');
+      const built = v?.builtAt || 'n/a';
+      const git = v?.git || 'n/a';
+      meta.innerHTML = `Uptime: <code>${h.uptimeSec}s</code> · Built: <code>${built}</code> · Git: <code>${git}</code>`;
+
+      const envT = document.querySelector('#env tbody');
+      envT.innerHTML = '';
+      for (const [k, present] of Object.entries(h.env || {})) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td><code>${k}</code></td><td>${present ? '✅' : '❌'}</td>`;
+        envT.appendChild(tr);
+      }
+
+      const sysT = document.querySelector('#sys tbody');
+      sysT.innerHTML = '';
+      sysT.appendChild(row('DB', h.db?.ok ? '✅' : '❌'));
+      sysT.appendChild(row('RSS (MB)', h.memoryMB?.rss ?? 'n/a'));
+      sysT.appendChild(row('HeapUsed (MB)', h.memoryMB?.heapUsed ?? 'n/a'));
+      sysT.appendChild(row('Service', v?.name ? `${v.name} ${v.version}` : 'n/a'));
+
+      function row(a, b) { const tr = document.createElement('tr'); tr.innerHTML = `<td>${a}</td><td>${b}</td>`; return tr; }
+    }
+    init();
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "backtest": "node src/engine/backtest.js",
     "live": "node src/engine/live.js",
     "initdb": "node src/storage/db.js",
-    "build:client": "cd client && npm install && npm run build && cd .. && mkdir -p .keep && cp -f client/public/wf.html .keep/wf.html 2>/dev/null || true && cp -f client/public/analytics.html .keep/analytics.html 2>/dev/null || true && rm -rf public/* && cp -r client/dist/* public/ && mkdir -p public && cp -f .keep/wf.html public/wf.html 2>/dev/null || true && cp -f .keep/analytics.html public/analytics.html 2>/dev/null || true && rm -rf .keep",
+    "build:client": "cd client && npm install && npm run build && cd .. && mkdir -p .keep && cp -f client/public/wf.html .keep/wf.html 2>/dev/null || true && cp -f client/public/analytics.html .keep/analytics.html 2>/dev/null || true && cp -f client/public/health.html .keep/health.html 2>/dev/null || true && rm -rf public/* && cp -r client/dist/* public/ && mkdir -p public && cp -f .keep/wf.html public/wf.html 2>/dev/null || true && cp -f .keep/analytics.html public/analytics.html 2>/dev/null || true && cp -f .keep/health.html public/health.html 2>/dev/null || true && rm -rf .keep",
     "bt": "node scripts/run-backtest.js",
     "fetch:binance": "node scripts/fetch-binance.js",
     "opt": "node scripts/optimize.js",


### PR DESCRIPTION
## Summary
- Implement comprehensive `/health` endpoint with diagnostics and add `/version` and `/download/:file` routes
- Add `health.html` frontend page and ensure it's preserved in `build:client`
- Deploy workflows now pass `GIT_SHA` and `BUILD_TIME` to Cloud Run

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:client`

------
https://chatgpt.com/codex/tasks/task_e_68a59daf4b28832583b2c56cb8522aba