### PR TITLE
feat: add paper trading live mode

### DIFF
--- a/client/public/live-metrics.json
+++ b/client/public/live-metrics.json
@@ -1,0 +1,7 @@
+{
+  "running": false,
+  "since": null,
+  "equity": 10000,
+  "pnl": 0,
+  "trades": []
+}

--- a/client/public/live.html
+++ b/client/public/live.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Paper Trading Live</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <h1>Paper Trading</h1>
+  <button onclick="fetch('/live/start',{method:'POST'})">Start</button>
+  <button onclick="fetch('/live/stop',{method:'POST'})">Stop</button>
+  <button onclick="fetch('/live/trades',{method:'DELETE'})">Reset</button>
+
+  <h2>Equity</h2>
+  <canvas id="chart"></canvas>
+
+  <h2>Trades</h2>
+  <table border="1"><thead><tr><th>Time</th><th>Side</th><th>Price</th><th>PnL</th></tr></thead><tbody id="tbody"></tbody></table>
+
+  <script>
+    async function refresh() {
+      const data = await fetch('/live').then(r=>r.json());
+      const tbody = document.getElementById('tbody');
+      tbody.innerHTML = '';
+      (data.trades || []).slice(-10).forEach(t=>{
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${new Date(t.ts).toISOString()}</td><td>${t.side}</td><td>${t.price}</td><td>${t.pnl??''}</td>`;
+        tbody.appendChild(tr);
+      });
+      chart.data.labels = data.trades.map(t=>new Date(t.ts).toLocaleTimeString());
+      chart.data.datasets[0].data = data.trades.map((t,i)=>10000+(data.trades.slice(0,i+1).map(x=>x.pnl||0).reduce((a,b)=>a+b,0)));
+      chart.update();
+    }
+    const ctx = document.getElementById('chart');
+    const chart = new Chart(ctx,{type:'line',data:{labels:[],datasets:[{label:'Equity',data:[]}]},options:{responsive:true}});
+    setInterval(refresh,5000);
+    refresh();
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "backtest": "node src/engine/backtest.js",
     "live": "node src/engine/live.js",
     "initdb": "node src/storage/db.js",
-    "build:client": "cd client && npm install && npm run build && cd .. && mkdir -p .keep && cp -f client/public/wf.html .keep/wf.html 2>/dev/null || true && cp -f client/public/analytics.html .keep/analytics.html 2>/dev/null || true && cp -f client/public/health.html .keep/health.html 2>/dev/null || true && rm -rf public/* && cp -r client/dist/* public/ && mkdir -p public && cp -f .keep/wf.html public/wf.html 2>/dev/null || true && cp -f .keep/analytics.html public/analytics.html 2>/dev/null || true && cp -f .keep/health.html public/health.html 2>/dev/null || true && rm -rf .keep",
+    "build:client": "cd client && npm install && npm run build && cd .. && mkdir -p .keep && cp -f client/public/wf.html .keep/wf.html 2>/dev/null || true && cp -f client/public/analytics.html .keep/analytics.html 2>/dev/null || true && cp -f client/public/health.html .keep/health.html 2>/dev/null || true && cp -f client/public/live.html .keep/live.html 2>/dev/null || true && rm -rf public/* && cp -r client/dist/* public/ && mkdir -p public && cp -f .keep/wf.html public/wf.html 2>/dev/null || true && cp -f .keep/analytics.html public/analytics.html 2>/dev/null || true && cp -f .keep/health.html public/health.html 2>/dev/null || true && cp -f .keep/live.html public/live.html 2>/dev/null || true && rm -rf .keep",
     "bt": "node scripts/run-backtest.js",
     "fetch:binance": "node scripts/fetch-binance.js",
     "opt": "node scripts/optimize.js",

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import bodyParser from 'body-parser';
 import { db } from './storage/db.js';
 import { createSingleUseInviteLink } from './notify/telegram.js';
 import { createCheckoutSession, stripeWebhook } from './payments/stripe.js';
+import { startLive, stopLive, resetLive, getLiveState } from './live.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicDir = path.join(__dirname, '..', 'client', 'public');
@@ -137,6 +138,11 @@ app.get('/api/telegram-invite', async (req, res) => {
     return res.status(500).json({ error: 'server_error' });
   }
 });
+
+app.get('/live', (_req, res) => res.json(getLiveState()));
+app.post('/live/start', (_req, res) => { startLive(); res.json({ ok: true }); });
+app.post('/live/stop', (_req, res) => { stopLive(); res.json({ ok: true }); });
+app.delete('/live/trades', (_req, res) => { resetLive(); res.json({ ok: true }); });
 
 // --- /analytics route ---
 

--- a/src/live.js
+++ b/src/live.js
@@ -1,0 +1,72 @@
+import { Pool } from 'pg';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { generateSignals } from './strategy.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const clientPublicDir = path.join(__dirname, '..', 'client', 'public');
+
+let running = false;
+let trades = [];
+let equity = 10000; // virtual start
+let loopTimer = null;
+let startTime = null;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+async function step() {
+  const { rows } = await pool.query(`
+    SELECT ts, open, high, low, close, volume
+    FROM candles
+    ORDER BY ts DESC
+    LIMIT 300
+  `);
+  const candles = rows.reverse().map(r => ({
+    ts: Number(r.ts),
+    open: Number(r.open),
+    high: Number(r.high),
+    low: Number(r.low),
+    close: Number(r.close),
+    volume: Number(r.volume),
+  }));
+
+  const params = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'config', 'params.json'), 'utf-8'));
+  const { trades: newTrades } = generateSignals(candles, params);
+
+  // Paimam tik paskutinį signalą
+  const last = newTrades[newTrades.length - 1];
+  if (last && (!trades.length || trades[trades.length - 1].ts !== last.ts)) {
+    trades.push(last);
+    if (last.pnl !== undefined) equity += last.pnl;
+    // Save metrics for frontend
+    const metrics = { running, since: startTime, equity, pnl: equity - 10000, trades };
+    fs.writeFileSync(path.join(clientPublicDir, 'live-metrics.json'), JSON.stringify(metrics, null, 2));
+  }
+}
+
+export function startLive() {
+  if (running) return;
+  running = true;
+  startTime = new Date().toISOString();
+  loopTimer = setInterval(step, 60 * 1000);
+}
+
+export function stopLive() {
+  running = false;
+  if (loopTimer) clearInterval(loopTimer);
+  loopTimer = null;
+}
+
+export function resetLive() {
+  trades = [];
+  equity = 10000;
+  fs.writeFileSync(path.join(clientPublicDir, 'live-metrics.json'), JSON.stringify({ running, since: startTime, equity, pnl: 0, trades: [] }, null, 2));
+}
+
+export function getLiveState() {
+  return { running, since: startTime, equity, pnl: equity - 10000, trades };
+}


### PR DESCRIPTION
## Summary
- implement paper trading loop with equity tracking and metrics output
- expose /live API for managing paper trading and viewing state
- add frontend page to show equity curve and recent trades

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68a5a7bba3d08325bb32e59bc7235226