### PR TITLE
feat: expose live trade history

### DIFF
--- a/client/public/live.html
+++ b/client/public/live.html
@@ -28,14 +28,27 @@
 
   <h2>Trades</h2>
   <table border="1"><thead><tr><th>Time</th><th>Entry</th><th>Exit</th><th>PnL</th></tr></thead><tbody id="tbody"></tbody></table>
-  <h2>Real Trades</h2>
-  <form id="histForm">
-    <label>From: <input type="date" id="histFrom"></label>
-    <label>To: <input type="date" id="histTo"></label>
-    <button type="button" id="histLoadBtn">Load</button>
-  </form>
-  <canvas id="realEquityChart" width="600" height="200"></canvas>
-  <table id="realTradesTable" border="1"><thead><tr><th>Time</th><th>Entry</th><th>Exit</th><th>PnL</th></tr></thead><tbody></tbody></table>
+
+  <h2>Closed Trades</h2>
+  <div id="historyFilters">
+    <label>Symbol: <input id="histSymbol"></label>
+    <label>Strategy: <input id="histStrategy"></label>
+    <label>From: <input type="datetime-local" id="histFrom"></label>
+    <label>To: <input type="datetime-local" id="histTo"></label>
+    <button type="button" id="histRefreshBtn">Refresh</button>
+    <span id="histLoading" style="display:none;">Loading...</span>
+  </div>
+  <div id="histEmpty" style="display:none;">No closed trades</div>
+  <div style="max-height:300px;overflow-y:auto;">
+    <table id="closedTradesTable" border="1">
+      <thead>
+        <tr>
+          <th>Closed At</th><th>Symbol</th><th>Strategy</th><th>Side</th><th>Qty</th><th>Entry</th><th>Exit</th><th>PnL</th><th>PnL %</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
 
   <section class="card">
     <h2>Real-time equity (DB)</h2>
@@ -99,43 +112,67 @@ setInterval(refresh,5000);
 loadCfg();
 refresh();
 
-async function loadRealHistory() {
-  const params = new URLSearchParams();
-  if (histFrom.value) params.append('from', histFrom.value);
-  if (histTo.value) params.append('to', histTo.value);
-  const res = await fetch('/live/history?' + params.toString());
+const histSymbol = document.getElementById('histSymbol');
+const histStrategy = document.getElementById('histStrategy');
+const histFrom = document.getElementById('histFrom');
+const histTo = document.getElementById('histTo');
+const histLoading = document.getElementById('histLoading');
+const histEmpty = document.getElementById('histEmpty');
+
+function formatDate(ms) {
+  const d = new Date(ms);
+  return d.toISOString().replace('T', ' ').slice(0,19);
+}
+
+function buildHistoryQuery() {
+  const q = new URLSearchParams();
+  if (histSymbol.value) q.set('symbol', histSymbol.value.trim());
+  if (histStrategy.value) q.set('strategy', histStrategy.value.trim());
+  if (histFrom.value) q.set('from', new Date(histFrom.value).toISOString());
+  if (histTo.value) q.set('to', new Date(histTo.value).toISOString());
+  return q.toString();
+}
+
+async function loadClosedTrades() {
+  histLoading.style.display = 'inline';
+  histEmpty.style.display = 'none';
+  const qs = buildHistoryQuery();
+  const res = await fetch('/live/history' + (qs ? '?' + qs : ''));
   const data = await res.json();
-  const tbody = document.querySelector('#realTradesTable tbody');
+  histLoading.style.display = 'none';
+  const tbody = document.querySelector('#closedTradesTable tbody');
   tbody.innerHTML = '';
-  (data.trades || []).forEach(t => {
+  const trades = data.closedTrades || [];
+  if (!trades.length) {
+    histEmpty.style.display = 'block';
+    return;
+  }
+  trades.slice(0,200).forEach(t => {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${new Date(t.ts).toISOString()}</td><td>${t.entry_price}</td><td>${t.exit_price}</td><td>${t.pnl}</td>`;
+    const pnl = t.pnl || 0;
+    const pnlPct = t.pnl_pct || 0;
+    tr.innerHTML = `
+      <td>${t.closed_at ? formatDate(t.closed_at) : ''}</td>
+      <td>${t.symbol || ''}</td>
+      <td>${t.strategy || ''}</td>
+      <td>${t.side || ''}</td>
+      <td>${t.qty ?? ''}</td>
+      <td>${t.entry_price ?? ''}</td>
+      <td>${t.exit_price ?? ''}</td>
+      <td style="color:${pnl>0?'green':pnl<0?'red':'inherit'}">${pnl.toFixed(2)}</td>
+      <td style="color:${pnlPct>0?'green':pnlPct<0?'red':'inherit'}">${pnlPct.toFixed(2)}</td>`;
     tbody.appendChild(tr);
   });
-  drawRealEquity(data.equity || []);
 }
 
-function drawRealEquity(points) {
-  const c = document.getElementById('realEquityChart');
-  const ctx = c.getContext('2d');
-  ctx.clearRect(0,0,c.width,c.height);
-  if (!points.length) return;
-  const minTs = points[0].ts;
-  const maxTs = points[points.length - 1].ts;
-  let minEq = Math.min(...points.map(p=>p.equity));
-  let maxEq = Math.max(...points.map(p=>p.equity));
-  if (maxEq === minEq) { minEq -= 1; maxEq += 1; }
-  ctx.beginPath();
-  points.forEach((p,i) => {
-    const x = maxTs === minTs ? 0 : (p.ts - minTs) / (maxTs - minTs) * c.width;
-    const y = c.height - (p.equity - minEq) / (maxEq - minEq) * c.height;
-    if (i === 0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
-  });
-  ctx.stroke();
-}
+document.getElementById('histRefreshBtn').addEventListener('click', loadClosedTrades);
 
-document.getElementById('histLoadBtn').addEventListener('click', loadRealHistory);
-loadRealHistory();
+// initial 24h load
+const now = new Date();
+histTo.value = new Date(now).toISOString().slice(0,16);
+histFrom.value = new Date(now.getTime() - 24*60*60*1000).toISOString().slice(0,16);
+loadClosedTrades();
+setInterval(loadClosedTrades, 30000);
   </script>
 
   <script>


### PR DESCRIPTION
## Summary
- add `/live/history` endpoint with filters to fetch closed paper trades
- show closed trades table on live dashboard with auto refresh

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f0d3efec83258836a5f5aee0f95a