### PR TITLE
feat: add real-time equity stream

### DIFF
--- a/client/public/live.html
+++ b/client/public/live.html
@@ -206,45 +206,28 @@ loadRealHistory();
     statsEl.textContent = `Points: ${points.length} | Equity: ${last.toFixed(2)} | MaxDD: ${maxDD.toFixed(2)}`;
   }
 
-  async function primeOnce(fromStr) {
-    const q = fromStr ? `?from=${encodeURIComponent(fromStr)}` : '';
-    const r = await fetch(`/live/equity${q}`);
-    const j = await r.json();
-    if (j.ok) {
-      points = j.points || [];
-      draw();
-      setStats();
-    }
-  }
-
   function connect() {
-    const fromStr = fromEl.value ? fromEl.value : '';
-    const url = fromStr ? `/live/equity/stream?from=${encodeURIComponent(fromStr)}` : '/live/equity/stream';
+    const params = [];
+    if (fromEl.value) params.push(`from=${encodeURIComponent(fromEl.value)}`);
+    const url = params.length ? `/live/equity-stream?${params.join('&')}` : '/live/equity-stream';
     evtSrc = new EventSource(url);
 
-    evtSrc.addEventListener('init', (ev) => {
+    evtSrc.onmessage = (ev) => {
       const data = JSON.parse(ev.data);
-      const pts = data.points || [];
-      if (pts.length) {
-        points = pts;
+      if (data.type === 'init') {
+        points = data.equity || [];
+        draw();
+        setStats();
+      } else if (data.type === 'append' && data.point) {
+        points.push(data.point);
         draw();
         setStats();
       }
-    });
+    };
 
-    evtSrc.addEventListener('tick', (ev) => {
-      const data = JSON.parse(ev.data);
-      const pts = data.points || [];
-      if (pts.length) {
-        points.push(...pts);
-        draw();
-        setStats();
-      }
-    });
-
-    evtSrc.addEventListener('error', () => {
-      // Tyliai – naršyklė bandys reconnectint; jei uždarom mes — bus closed
-    });
+    evtSrc.onerror = () => {
+      // Silent – browser will retry
+    };
 
     btnConnect.disabled = true;
     btnDisconnect.disabled = false;
@@ -260,10 +243,7 @@ loadRealHistory();
   const now = Date.now();
   fromEl.value = isoDateToInput(now - 7*24*3600*1000); // default – paskutinės 7 d.
 
-  btnConnect.addEventListener('click', async () => {
-    await primeOnce(fromEl.value); // pasikraunam pradinę kreivę
-    connect();                     // tada prisijungiam prie SSE
-  });
+  btnConnect.addEventListener('click', connect);
   btnDisconnect.addEventListener('click', disconnect);
 
 })();

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import { createSingleUseInviteLink } from './notify/telegram.js';
 import { createCheckoutSession, stripeWebhook } from './payments/stripe.js';
 import { startLive, stopLive, resetLive, getLiveState, getLiveConfig, setLiveConfig } from './live.js';
 import { ingestOnce, getIngestHealth } from './ingest.js';
+import { equityRoutes } from './routes/equity.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicDir = path.join(__dirname, '..', 'client', 'public');
@@ -17,18 +18,6 @@ const app = express();
 // Alias db pool for clarity
 const pool = db;
 
-async function loadClosedPnLSince(fromMs = null) {
-  const q = `
-    SELECT ts, pnl
-    FROM paper_trades
-    WHERE status='CLOSED'
-      AND ($1::bigint IS NULL OR ts >= $1::bigint)
-    ORDER BY ts ASC
-    LIMIT 20000
-  `;
-  const { rows } = await db.query(q, [fromMs]);
-  return rows.map(r => ({ ts: Number(r.ts), pnl: Number(r.pnl ?? 0) }));
-}
 
 app.use(cors());
 app.use(cookieParser());
@@ -38,6 +27,9 @@ app.post('/webhook/stripe', bodyParser.raw({ type: 'application/json' }), stripe
 
 // JSON body for general APIs
 app.use(bodyParser.json());
+
+// Equity routes (SSE and fetch)
+equityRoutes(app);
 
 function bool(v) { return !!(v && String(v).length); }
 
@@ -193,105 +185,6 @@ app.post('/live/config', express.json(), async (req, res) => {
   res.json(saved);
 });
 
-// GET /live/equity?from=YYYY-MM-DD
-app.get('/live/equity', async (req, res) => {
-  res.set('Cache-Control', 'no-store');
-  const fromStr = (req.query.from || '').toString().trim();
-  const fromMs = fromStr ? (Number.isNaN(Date.parse(fromStr)) ? null : Date.parse(fromStr)) : null;
-
-  try {
-    const rows = await loadClosedPnLSince(fromMs);
-    let eq = 0, peak = -Infinity, maxDD = 0;
-    const equity = rows.map(r => {
-      eq += r.pnl || 0;
-      if (eq > peak) peak = eq;
-      const dd = peak - eq;
-      if (dd > maxDD) maxDD = dd;
-      return { ts: r.ts, equity: eq };
-    });
-
-    return res.json({
-      ok: true,
-      from: fromMs,
-      points: equity,
-      lastTs: equity.length ? equity[equity.length - 1].ts : null,
-      lastEq: equity.length ? equity[equity.length - 1].equity : 0,
-      maxDrawdown: Number(maxDD.toFixed(2)),
-    });
-  } catch (e) {
-    console.error('[/live/equity] error:', e);
-    return res.status(500).json({ ok: false, error: 'db_error' });
-  }
-});
-
-// GET /live/equity/stream?from=YYYY-MM-DD
-// Server-Sent Events srautas: kas 2s tikrina naujus CLOSED trade'us, pildo equity taškus ir siunčia tik naujus
-app.get('/live/equity/stream', async (req, res) => {
-  // SSE antraštės
-  res.writeHead(200, {
-    'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-store',
-    'Connection': 'keep-alive',
-    'X-Accel-Buffering': 'no',
-  });
-
-  const send = (event, data) => {
-    res.write(`event: ${event}\n`);
-    res.write(`data: ${JSON.stringify(data)}\n\n`);
-  };
-
-  const fromStr = (req.query.from || '').toString().trim();
-  let fromMs = fromStr ? (Number.isNaN(Date.parse(fromStr)) ? null : Date.parse(fromStr)) : null;
-
-  let lastTs = fromMs || null;
-  let eq = 0; // sukaupsim pagal atsiųstus taškus šiame ryšyje
-
-  try {
-    // inicialus dump nuo fromMs
-    const rows = await loadClosedPnLSince(fromMs);
-    const initPoints = [];
-    for (const r of rows) {
-      eq += r.pnl || 0;
-      initPoints.push({ ts: r.ts, equity: eq });
-      lastTs = r.ts;
-    }
-    send('init', {
-      ok: true,
-      points: initPoints,
-      lastTs,
-      lastEq: eq,
-    });
-  } catch (e) {
-    console.error('[/live/equity/stream] init error:', e);
-    send('error', { ok: false, error: 'db_error' });
-  }
-
-  // polling ciklas kas 2s
-  const timer = setInterval(async () => {
-    try {
-      // imame naujesnius nei lastTs
-      const rows = await loadClosedPnLSince(lastTs != null ? (lastTs + 1) : null);
-      const newPoints = [];
-      for (const r of rows) {
-        eq += r.pnl || 0;
-        newPoints.push({ ts: r.ts, equity: eq });
-        lastTs = r.ts;
-      }
-      if (newPoints.length) {
-        send('tick', { points: newPoints, lastTs, lastEq: eq });
-      }
-    } catch (e) {
-      console.error('[/live/equity/stream] poll error:', e);
-      send('error', { ok: false, error: 'db_error' });
-    }
-  }, 2000);
-
-  // ryšio uždarymas
-  req.on('close', () => {
-    clearInterval(timer);
-    try { res.end(); } catch (_) {}
-  });
-});
 
 app.get('/live/history', async (req, res) => {
   const parseDateMs = (v) => {

--- a/src/routes/equity.js
+++ b/src/routes/equity.js
@@ -1,0 +1,174 @@
+import express from 'express';
+import { db, listen } from '../storage/db.js';
+
+const router = express.Router();
+const STARTING_EQUITY = 10000;
+
+function parseDate(v) {
+  if (!v) return null;
+  const t = Date.parse(String(v));
+  return Number.isNaN(t) ? null : t;
+}
+
+function parseParams(raw) {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const obj = {};
+    for (const part of String(raw).split(/[;,]/)) {
+      const [k, v] = part.split('=').map(s => s.trim());
+      if (k && v) obj[k] = isNaN(v) ? v : Number(v);
+    }
+    return Object.keys(obj).length ? obj : null;
+  }
+}
+
+function parseFilters(q) {
+  return {
+    symbol: (q.symbol || '').toString().trim() || null,
+    strategy: (q.strategy || '').toString().trim() || null,
+    params: parseParams(q.params),
+    from: parseDate(q.from),
+    to: parseDate(q.to),
+  };
+}
+
+async function startingEquity() {
+  try {
+    const { rows } = await db.query('SELECT balance_start FROM paper_state WHERE id=1');
+    return rows.length ? Number(rows[0].balance_start) : STARTING_EQUITY;
+  } catch {
+    return STARTING_EQUITY;
+  }
+}
+
+async function tableExists(name) {
+  const { rows } = await db.query('SELECT to_regclass($1) AS t', [name]);
+  return !!rows[0].t;
+}
+
+async function loadEquitySeries(filters, limit = 1000) {
+  const base = await startingEquity();
+  if (await tableExists('equity_history')) {
+    const { symbol, strategy, params, from, to } = filters;
+    const cond = [];
+    const vals = [];
+    let i = 1;
+    if (symbol) { cond.push(`symbol=$${i++}`); vals.push(symbol); }
+    if (strategy) { cond.push(`strategy=$${i++}`); vals.push(strategy); }
+    if (params) { cond.push(`params @> $${i++}`); vals.push(JSON.stringify(params)); }
+    if (from) { cond.push(`ts >= to_timestamp($${i++}/1000.0)`); vals.push(from); }
+    if (to) { cond.push(`ts <= to_timestamp($${i++}/1000.0)`); vals.push(to); }
+    const where = cond.length ? `WHERE ${cond.join(' AND ')}` : '';
+    const q = `SELECT EXTRACT(EPOCH FROM ts)*1000 AS ts, equity FROM equity_history ${where} ORDER BY ts ASC LIMIT ${limit}`;
+    const { rows } = await db.query(q, vals);
+    const points = rows.map(r => ({ ts: Number(r.ts), equity: Number(r.equity) }));
+    const last = points[points.length - 1];
+    return { points, lastTs: last ? last.ts : null, lastEq: last ? last.equity : base };
+  } else {
+    const { symbol, strategy, params, from, to } = filters;
+    const cond = ["status='CLOSED'"];
+    const vals = [];
+    let i = 1;
+    if (symbol) { cond.push(`symbol=$${i++}`); vals.push(symbol); }
+    if (strategy) { cond.push(`strategy=$${i++}`); vals.push(strategy); }
+    if (params) { cond.push(`params @> $${i++}`); vals.push(JSON.stringify(params)); }
+    if (from) { cond.push(`closed_at >= $${i++}`); vals.push(from); }
+    if (to) { cond.push(`closed_at <= $${i++}`); vals.push(to); }
+    const where = `WHERE ${cond.join(' AND ')}`;
+    const q = `SELECT closed_at AS ts, pnl FROM paper_trades ${where} ORDER BY closed_at ASC LIMIT ${limit}`;
+    const { rows } = await db.query(q, vals);
+    let eq = base;
+    const points = [];
+    for (const r of rows) {
+      eq += Number(r.pnl || 0);
+      points.push({ ts: Number(r.ts), equity: Number(eq) });
+    }
+    const last = points[points.length - 1];
+    return { points, lastTs: last ? last.ts : null, lastEq: last ? last.equity : base };
+  }
+}
+
+async function loadNewEquityPoints(filters, sinceTs, lastEq) {
+  const { symbol, strategy, params, to } = filters;
+  const cond = ["status='CLOSED'", `closed_at > $1`];
+  const vals = [sinceTs];
+  let i = 2;
+  if (symbol) { cond.push(`symbol=$${i++}`); vals.push(symbol); }
+  if (strategy) { cond.push(`strategy=$${i++}`); vals.push(strategy); }
+  if (params) { cond.push(`params @> $${i++}`); vals.push(JSON.stringify(params)); }
+  if (to) { cond.push(`closed_at <= $${i++}`); vals.push(to); }
+  const q = `SELECT closed_at AS ts, pnl FROM paper_trades WHERE ${cond.join(' AND ')} ORDER BY closed_at ASC`;
+  const { rows } = await db.query(q, vals);
+  const points = [];
+  let eq = lastEq;
+  let lastTs = sinceTs;
+  for (const r of rows) {
+    eq += Number(r.pnl || 0);
+    lastTs = Number(r.ts);
+    points.push({ ts: lastTs, equity: eq });
+  }
+  return { points, lastTs, lastEq: eq };
+}
+
+router.get('/live/equity', async (req, res) => {
+  res.set('Cache-Control', 'no-store');
+  const filters = parseFilters(req.query);
+  try {
+    const { points } = await loadEquitySeries(filters);
+    res.json({ ok: true, filters, equity: points });
+  } catch (e) {
+    console.error('[/live/equity] error:', e);
+    res.status(500).json({ ok: false, error: 'db_error' });
+  }
+});
+
+router.get('/live/equity-stream', async (req, res) => {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-store',
+    'Connection': 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  });
+  res.write('retry: 3000\n\n');
+  const send = (obj) => {
+    res.write(`data: ${JSON.stringify(obj)}\n\n`);
+  };
+
+  const filters = parseFilters(req.query);
+  let { points, lastTs, lastEq } = await loadEquitySeries(filters);
+  send({ type: 'init', filters, equity: points });
+
+  let releaseListen = null;
+  try {
+    releaseListen = await listen('equity_update', async () => {
+      const r = await loadNewEquityPoints(filters, lastTs ?? 0, lastEq);
+      r.points.forEach(p => send({ type: 'append', point: p }));
+      lastTs = r.lastTs;
+      lastEq = r.lastEq;
+    });
+  } catch {
+    releaseListen = null;
+  }
+
+  const pollIv = setInterval(async () => {
+    const r = await loadNewEquityPoints(filters, lastTs ?? 0, lastEq);
+    r.points.forEach(p => send({ type: 'append', point: p }));
+    lastTs = r.lastTs;
+    lastEq = r.lastEq;
+  }, 5000);
+
+  const hb = setInterval(() => { res.write('event: ping\n\n'); }, 25000);
+
+  req.on('close', () => {
+    clearInterval(pollIv);
+    clearInterval(hb);
+    if (releaseListen) releaseListen();
+    try { res.end(); } catch {}
+  });
+});
+
+export function equityRoutes(app) {
+  app.use(router);
+}

--- a/src/storage/migrations/2025-08-equity-realtime.sql
+++ b/src/storage/migrations/2025-08-equity-realtime.sql
@@ -1,0 +1,19 @@
+-- Ensure fast filters
+CREATE INDEX IF NOT EXISTS idx_paper_trades_closed_at ON paper_trades (closed_at);
+CREATE INDEX IF NOT EXISTS idx_paper_trades_status ON paper_trades (status);
+
+-- Notification function
+CREATE OR REPLACE FUNCTION notify_equity_update() RETURNS trigger AS $$
+BEGIN
+  PERFORM pg_notify('equity_update', COALESCE(NEW.symbol,'') || '|' || COALESCE(NEW.strategy,''));
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger on CLOSED trades
+DROP TRIGGER IF EXISTS trg_equity_update ON paper_trades;
+CREATE TRIGGER trg_equity_update
+AFTER INSERT OR UPDATE OF status ON paper_trades
+FOR EACH ROW
+WHEN (NEW.status = 'CLOSED')
+EXECUTE FUNCTION notify_equity_update();


### PR DESCRIPTION
## Summary
- add postgres LISTEN helper and equity-update trigger
- expose `/live/equity-stream` SSE and `/live/equity` fetch endpoints
- update live.html to consume real-time equity stream

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a8f1c80aa08325a89e937f6a30f4a5