### PR TITLE
Add Binance Futures Testnet integration skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ BINANCE_BASE=https://api.binance.com
 SYMBOL=SOLUSDT
 INTERVAL=1m
 
+# Binance Futures Testnet
+BINANCE_BASE_URL=https://testnet.binancefuture.com
+BINANCE_API_KEY=
+BINANCE_API_SECRET=
+BINANCE_RECV_WINDOW=5000
+
 # Telegram
 TELEGRAM_BOT_TOKEN=replace_with_your_bot_token
 TELEGRAM_PUBLIC_CHAT_ID=replace_with_public_channel_id_or_chat_id

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ cp -r client/dist/* public/
 cp .env.example .env
 ```
 
+### Binance Futures Testnet
+To enable testnet account and order endpoints, set the following variables in `.env`:
+
+```
+BINANCE_BASE_URL=https://testnet.binancefuture.com
+BINANCE_API_KEY=your_key
+BINANCE_API_SECRET=your_secret
+BINANCE_RECV_WINDOW=5000
+```
+
 5) Init DB
 ```bash
 npm run initdb

--- a/client/public/live.html
+++ b/client/public/live.html
@@ -7,6 +7,25 @@
 </head>
 <body>
   <h1>Paper Trading</h1>
+  <section id="binance">
+    <h2>Binance Testnet</h2>
+    <button id="pingBtn">Ping</button> <span id="pingRes"></span>
+    <div>
+      <button id="accountBtn">Account</button>
+      <pre id="accountOut" style="white-space:pre-wrap"></pre>
+    </div>
+    <h3>Test Order</h3>
+    <form id="orderForm">
+      <input name="symbol" placeholder="BTCUSDT">
+      <select name="side"><option>BUY</option><option>SELL</option></select>
+      <select name="type"><option>MARKET</option><option>LIMIT</option></select>
+      <input name="quantity" type="number" step="0.0001" placeholder="qty">
+      <input name="price" type="number" step="0.01" placeholder="price">
+      <label><input type="checkbox" name="dryRun" checked> Dry Run</label>
+      <button type="submit">Send</button>
+    </form>
+    <pre id="orderRes" style="white-space:pre-wrap"></pre>
+  </section>
   <form id="cfg">
     <label>TP %: <input step="0.0001" type="number" id="tpPct"></label>
     <label>SL %: <input step="0.0001" type="number" id="slPct"></label>
@@ -66,6 +85,38 @@
   </section>
 
   <script>
+const pingBtn = document.getElementById('pingBtn');
+pingBtn.addEventListener('click', async () => {
+  const r = await fetch('/binance/ping').then(r=>r.json()).catch(e=>({ error: String(e) }));
+  document.getElementById('pingRes').textContent = JSON.stringify(r);
+});
+
+document.getElementById('accountBtn').addEventListener('click', async () => {
+  const r = await fetch('/binance/account').then(r=>r.json()).catch(e=>({ error: String(e) }));
+  if (r && r.totalWalletBalance !== undefined) {
+    const positions = (r.positions || []).filter(p => Number(p.positionAmt));
+    const lines = [`Wallet: ${r.totalWalletBalance}`, `Available: ${r.availableBalance}`, 'Positions:', ...positions.map(p => `${p.symbol} ${p.positionAmt}`)];
+    document.getElementById('accountOut').textContent = lines.join('\n');
+  } else {
+    document.getElementById('accountOut').textContent = JSON.stringify(r, null, 2);
+  }
+});
+
+document.getElementById('orderForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const f = e.target;
+  const payload = {
+    symbol: f.symbol.value.toUpperCase(),
+    side: f.side.value,
+    type: f.type.value,
+    quantity: Number(f.quantity.value),
+    price: f.price.value ? Number(f.price.value) : undefined,
+    dryRun: f.dryRun.checked,
+  };
+  const r = await fetch('/binance/order', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) }).then(r=>r.json()).catch(e=>({ error: String(e) }));
+  document.getElementById('orderRes').textContent = JSON.stringify(r, null, 2);
+});
+
 async function loadCfg() {
   const c = await fetch('/live/config').then(r=>r.json());
   tpPct.value = c.tpPct; slPct.value = c.slPct; trailPct.value = c.trailPct;

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import { startLive, stopLive, resetLive, getLiveState, getLiveConfig, setLiveCon
 import { ingestOnce, getIngestHealth } from './ingest.js';
 import { equityRoutes } from './routes/equity.js';
 import { getStrategies } from './strategies/index.js';
+import binanceRoutes from './integrations/binance/routes.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicDir = path.join(__dirname, '..', 'client', 'public');
@@ -31,6 +32,7 @@ app.use(bodyParser.json());
 
 // Equity routes (SSE and fetch)
 equityRoutes(app);
+app.use('/binance', binanceRoutes);
 
 app.get('/strategies', (_req, res) => {
   res.json(getStrategies().map(s => ({ id: s.id, label: s.id.toUpperCase() })));

--- a/src/integrations/binance/client.js
+++ b/src/integrations/binance/client.js
@@ -1,0 +1,84 @@
+import axios from 'axios';
+import crypto from 'crypto';
+
+const BASE_URL = process.env.BINANCE_BASE_URL || 'https://testnet.binancefuture.com';
+const API_KEY = process.env.BINANCE_API_KEY || '';
+const API_SECRET = process.env.BINANCE_API_SECRET || '';
+const RECV_WINDOW = Number(process.env.BINANCE_RECV_WINDOW) || 5000;
+
+const http = axios.create({ baseURL: BASE_URL, timeout: 10000 });
+
+let timeOffset = 0;
+
+async function timeSync() {
+  try {
+    const res = await http.get('/fapi/v1/time');
+    const serverTime = res.data.serverTime;
+    timeOffset = serverTime - Date.now();
+  } catch (e) {
+    // ignore
+  }
+}
+
+// sync now and every 60s
+setInterval(timeSync, 60_000).unref();
+timeSync();
+
+function buildQuery(params = {}) {
+  return Object.keys(params)
+    .filter(k => params[k] !== undefined && params[k] !== null)
+    .sort()
+    .map(k => `${k}=${encodeURIComponent(params[k])}`)
+    .join('&');
+}
+
+function sign(query) {
+  return crypto.createHmac('sha256', API_SECRET).update(query).digest('hex');
+}
+
+async function send(method, path, params = {}, opts = {}) {
+  const { signed = false } = opts;
+  const q = { ...params };
+  const headers = {};
+
+  if (signed) {
+    q.timestamp = Date.now() + timeOffset;
+    q.recvWindow = RECV_WINDOW;
+  }
+
+  let qs = buildQuery(q);
+  if (signed) {
+    qs = qs ? `${qs}&signature=${sign(qs)}` : `signature=${sign('')}`;
+    headers['X-MBX-APIKEY'] = API_KEY;
+  }
+
+  let url = path;
+  let data;
+  if (method === 'GET' || method === 'DELETE') {
+    if (qs) url += `?${qs}`;
+  } else {
+    data = qs;
+    headers['Content-Type'] = 'application/x-www-form-urlencoded';
+  }
+
+  for (let attempts = 0; attempts < 3; attempts++) {
+    try {
+      const res = await http.request({ method, url, data, headers });
+      return res.data;
+    } catch (err) {
+      const status = err.response?.status;
+      if ((status === 429 || status === 418) && attempts < 2) {
+        const delay = 500 + Math.random() * 1000;
+        await new Promise(r => setTimeout(r, delay));
+        continue;
+      }
+      throw err.response?.data || err;
+    }
+  }
+}
+
+function getTimeOffset() {
+  return timeOffset;
+}
+
+export default { send, timeSync, getTimeOffset };

--- a/src/integrations/binance/routes.js
+++ b/src/integrations/binance/routes.js
@@ -1,0 +1,70 @@
+import { Router } from 'express';
+import binance from './client.js';
+
+const router = Router();
+
+router.get('/ping', async (_req, res) => {
+  try {
+    const [ping, time] = await Promise.all([
+      binance.send('GET', '/fapi/v1/ping'),
+      binance.send('GET', '/fapi/v1/time'),
+    ]);
+    res.json({ ping, time, timeOffset: binance.getTimeOffset() });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: String(e) });
+  }
+});
+
+router.get('/account', async (_req, res) => {
+  try {
+    const data = await binance.send('GET', '/fapi/v2/account', {}, { signed: true });
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ ok: false, error: String(e) });
+  }
+});
+
+router.get('/open-orders', async (req, res) => {
+  try {
+    const { symbol } = req.query;
+    const data = await binance.send('GET', '/fapi/v1/openOrders', { symbol }, { signed: true });
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ ok: false, error: String(e) });
+  }
+});
+
+router.get('/positions', async (req, res) => {
+  try {
+    const { symbol } = req.query;
+    const data = await binance.send('GET', '/fapi/v2/positionRisk', { symbol }, { signed: true });
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ ok: false, error: String(e) });
+  }
+});
+
+router.post('/order', async (req, res) => {
+  try {
+    const { symbol, side, type = 'MARKET', quantity, price, dryRun = true, timeInForce = 'GTC', reduceOnly = false } = req.body;
+    const common = { symbol, side, type, quantity, reduceOnly };
+    const payload = (type === 'LIMIT') ? { ...common, price, timeInForce } : common;
+    const path = dryRun ? '/fapi/v1/order/test' : '/fapi/v1/order';
+    const data = await binance.send('POST', path, payload, { signed: true });
+    res.json({ ok: true, dryRun, data });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: String(e) });
+  }
+});
+
+router.delete('/order', async (req, res) => {
+  try {
+    const { symbol, orderId, origClientOrderId } = req.query;
+    const data = await binance.send('DELETE', '/fapi/v1/order', { symbol, orderId, origClientOrderId }, { signed: true });
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ ok: false, error: String(e) });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add Binance client with HMAC signing and time sync for Testnet
- expose REST routes for account, orders, and status
- wire routes and minimal frontend to test Testnet calls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check src/integrations/binance/client.js && node --check src/integrations/binance/routes.js && node --check src/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68a98a87f9cc832598a8cf766efa0e31