### PR TITLE
Add Binance user data stream service

### DIFF
--- a/client/public/live.html
+++ b/client/public/live.html
@@ -7,6 +7,19 @@
 </head>
 <body>
   <h1>Paper Trading</h1>
+  <section id="userStream">
+    <h2>User Data Stream</h2>
+    <div>Stream status: <span id="udsState">disconnected</span> <button id="udsReconnect">Reconnect</button></div>
+    <h3>Orders</h3>
+    <table border="1" id="udsOrders">
+      <thead><tr><th>Time</th><th>Symbol</th><th>Side</th><th>Status</th><th>LastQty</th><th>LastPrice</th><th>CumQty</th><th>AvgPrice</th><th>RealizedPnL</th></tr></thead>
+      <tbody></tbody>
+    </table>
+    <h3>Account</h3>
+    <pre id="udsAccount"></pre>
+    <h3>Positions</h3>
+    <pre id="udsPositions"></pre>
+  </section>
   <section id="binance">
     <h2>Binance Testnet</h2>
     <button id="pingBtn">Ping</button> <span id="pingRes"></span>
@@ -237,6 +250,48 @@ async function loadStrategyOptions() {
 
 loadStrategyOptions().then(loadClosedTrades);
 setInterval(loadClosedTrades, 30000);
+  </script>
+  <script>
+  (function() {
+    const stateEl = document.getElementById('udsState');
+    const btn = document.getElementById('udsReconnect');
+    const ordersBody = document.querySelector('#udsOrders tbody');
+    const accEl = document.getElementById('udsAccount');
+    const posEl = document.getElementById('udsPositions');
+    let es;
+
+    function connect() {
+      stateEl.textContent = 'connecting';
+      es = new EventSource('/live/user-stream');
+      es.onmessage = (ev) => {
+        const msg = JSON.parse(ev.data);
+        if (msg.type === 'init') {
+          if (msg.account) {
+            accEl.textContent = JSON.stringify({ wallet: msg.account.totalWalletBalance, available: msg.account.availableBalance }, null, 2);
+          }
+          if (msg.positions) posEl.textContent = JSON.stringify(msg.positions, null, 2);
+        } else if (msg.type === 'order') {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td>${new Date(msg.T).toLocaleTimeString()}</td><td>${msg.s}</td><td>${msg.S}</td><td>${msg.X}</td><td>${msg.l}</td><td>${msg.L}</td><td>${msg.z}</td><td>${msg.ap}</td><td>${msg.rp}</td>`;
+          ordersBody.prepend(tr);
+          while (ordersBody.children.length > 20) ordersBody.removeChild(ordersBody.lastChild);
+        } else if (msg.type === 'account') {
+          accEl.textContent = JSON.stringify(msg.balances || [], null, 2);
+          posEl.textContent = JSON.stringify(msg.positions || [], null, 2);
+        } else if (msg.type === 'status') {
+          stateEl.textContent = msg.state;
+        }
+      };
+      es.onerror = () => { stateEl.textContent = 'reconnecting'; };
+    }
+
+    btn.addEventListener('click', () => {
+      if (es) es.close();
+      connect();
+    });
+
+    connect();
+  })();
   </script>
 
   <script>

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import { createCheckoutSession, stripeWebhook } from './payments/stripe.js';
 import { startLive, stopLive, resetLive, getLiveState, getLiveConfig, setLiveConfig } from './live.js';
 import { ingestOnce, getIngestHealth } from './ingest.js';
 import { equityRoutes } from './routes/equity.js';
+import { userStreamRoutes } from './routes/live.js';
 import { getStrategies } from './strategies/index.js';
 import binanceRoutes from './integrations/binance/routes.js';
 
@@ -32,6 +33,7 @@ app.use(bodyParser.json());
 
 // Equity routes (SSE and fetch)
 equityRoutes(app);
+userStreamRoutes(app);
 app.use('/binance', binanceRoutes);
 
 app.get('/strategies', (_req, res) => {

--- a/src/integrations/binance/routes.js
+++ b/src/integrations/binance/routes.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import binance from './client.js';
+import userData from './userDataService.js';
 
 const router = Router();
 
@@ -65,6 +66,39 @@ router.delete('/order', async (req, res) => {
   } catch (e) {
     res.status(500).json({ ok: false, error: String(e) });
   }
+});
+
+// --- User data stream helpers (debug / dev) ---
+
+router.post('/user-data/start', async (_req, res) => {
+  try {
+    const listenKey = await userData.start();
+    res.json({ ok: true, listenKey });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: String(e) });
+  }
+});
+
+router.post('/user-data/keepalive', async (_req, res) => {
+  try {
+    await userData.keepAlive();
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: String(e) });
+  }
+});
+
+router.post('/user-data/stop', async (_req, res) => {
+  try {
+    await userData.stop();
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: String(e) });
+  }
+});
+
+router.get('/user-data/status', (_req, res) => {
+  res.json({ ok: true, status: userData.status() });
 });
 
 export default router;

--- a/src/integrations/binance/userDataService.js
+++ b/src/integrations/binance/userDataService.js
@@ -1,0 +1,171 @@
+import EventEmitter from 'events';
+import WebSocket from 'ws';
+import binance from './client.js';
+import { db } from '../../storage/db.js';
+
+const WS_BASE = 'wss://fstream.binancefuture.com/ws';
+const BACKOFF = [2000, 5000, 10000, 30000, 60000];
+
+class UserDataService extends EventEmitter {
+  constructor() {
+    super();
+    this.listenKey = null;
+    this.ws = null;
+    this.keepAliveTimer = null;
+    this.reconnectTimer = null;
+    this.backoffIdx = 0;
+  }
+
+  status() {
+    return {
+      listenKey: this.listenKey,
+      connected: this.ws?.readyState === WebSocket.OPEN,
+    };
+  }
+
+  async start() {
+    if (!this.listenKey) {
+      await this._refreshListenKey();
+    }
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      await this._connectWs();
+    }
+    if (!this.keepAliveTimer) {
+      this.keepAliveTimer = setInterval(() => this.keepAlive(), 30 * 60 * 1000).unref();
+    }
+    return this.listenKey;
+  }
+
+  async _refreshListenKey() {
+    const data = await binance.send('POST', '/fapi/v1/listenKey', {}, { signed: true });
+    this.listenKey = data.listenKey;
+    this.emit('user:listenKey', { state: 'connected', listenKey: this.listenKey });
+  }
+
+  async _connectWs() {
+    if (!this.listenKey) await this._refreshListenKey();
+    const url = `${WS_BASE}/${this.listenKey}`;
+    this.ws = new WebSocket(url);
+
+    this.ws.on('open', () => {
+      this.backoffIdx = 0;
+      this.emit('user:listenKey', { state: 'connected' });
+    });
+
+    this.ws.on('message', (raw) => this._handleMessage(raw));
+
+    this.ws.on('close', () => {
+      this.emit('user:listenKey', { state: 'reconnecting' });
+      this._scheduleReconnect();
+    });
+
+    this.ws.on('error', () => {
+      // handled by close
+    });
+  }
+
+  _scheduleReconnect() {
+    const delay = BACKOFF[this.backoffIdx] || BACKOFF[BACKOFF.length - 1];
+    if (this.backoffIdx < BACKOFF.length - 1) this.backoffIdx += 1;
+    clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = setTimeout(() => this._reconnect(), delay).unref();
+  }
+
+  async _reconnect() {
+    try {
+      await this._refreshListenKey();
+      await this._connectWs();
+    } catch {
+      this._scheduleReconnect();
+    }
+  }
+
+  async keepAlive() {
+    if (!this.listenKey) return;
+    try {
+      await binance.send('PUT', '/fapi/v1/listenKey', { listenKey: this.listenKey }, { signed: true });
+    } catch (e) {
+      // if keepalive fails, force reconnect
+      console.error('keepAlive failed', e.message);
+      await this._reconnect();
+    }
+  }
+
+  async stop() {
+    if (this.keepAliveTimer) { clearInterval(this.keepAliveTimer); this.keepAliveTimer = null; }
+    if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
+    if (this.ws) {
+      try { this.ws.close(); } catch {}
+      this.ws = null;
+    }
+    if (this.listenKey) {
+      try { await binance.send('DELETE', '/fapi/v1/listenKey', { listenKey: this.listenKey }, { signed: true }); } catch {}
+    }
+    this.listenKey = null;
+    this.emit('user:listenKey', { state: 'stopped' });
+  }
+
+  _handleMessage(raw) {
+    let msg;
+    try { msg = JSON.parse(raw); } catch { return; }
+    if (msg.e === 'ORDER_TRADE_UPDATE') {
+      const o = msg.o || {};
+      const evt = {
+        type: 'ORDER',
+        T: msg.T,
+        s: o.s,
+        S: o.S,
+        X: o.X,
+        x: o.x,
+        i: o.i,
+        q: o.q,
+        z: o.z,
+        ap: o.ap,
+        L: o.L,
+        l: o.l,
+        rp: o.rp,
+        ps: o.ps,
+      };
+      this.emit('user:order_trade_update', evt);
+      this._applyOrderUpdate(evt).catch(err => console.error('order update db error', err));
+    } else if (msg.e === 'ACCOUNT_UPDATE') {
+      const evt = {
+        type: 'ACCOUNT',
+        T: msg.T,
+        balances: (msg.a?.B || []).map(b => ({ asset: b.a, walletBalance: b.wb, crossWallet: b.cw })),
+        positions: (msg.a?.P || []).map(p => ({ s: p.s, pa: p.pa, ep: p.ep, up: p.up, mt: p.mt })),
+      };
+      this.emit('user:account_update', evt);
+    }
+  }
+
+  async _applyOrderUpdate(o) {
+    // Basic sync of fills to paper_trades table
+    if (o.X === 'PARTIALLY_FILLED' || o.X === 'FILLED') {
+      const qty = Number(o.z || 0);
+      await db.query(
+        `UPDATE paper_trades SET size=$1 WHERE status='OPEN' AND symbol=$2 ORDER BY id DESC LIMIT 1`,
+        [qty, o.s]
+      );
+    }
+    if (o.X === 'FILLED' && o.x === 'TRADE') {
+      const price = Number(o.ap || o.L || 0);
+      const ts = Number(o.T);
+      const rp = Number(o.rp || 0);
+      if (o.S === 'BUY') {
+        await db.query(
+          `UPDATE paper_trades SET entry_price=$1, opened_at=$2 WHERE status='OPEN' AND symbol=$3 ORDER BY id DESC LIMIT 1`,
+          [price, ts, o.s]
+        );
+      } else {
+        await db.query(
+          `UPDATE paper_trades SET exit_price=$1, closed_at=$2, pnl=COALESCE(pnl,0)+$3, status='CLOSED' WHERE status='OPEN' AND symbol=$4 ORDER BY id ASC LIMIT 1`,
+          [price, ts, rp, o.s]
+        );
+      }
+    }
+  }
+}
+
+const svc = new UserDataService();
+export default svc;

--- a/src/routes/live.js
+++ b/src/routes/live.js
@@ -1,0 +1,56 @@
+import express from 'express';
+import binance from '../integrations/binance/client.js';
+import userData from '../integrations/binance/userDataService.js';
+
+const router = express.Router();
+
+router.get('/live/user-stream', async (_req, res) => {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-store',
+    Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  });
+  res.write('retry: 3000\n\n');
+
+  const send = (obj) => res.write(`data: ${JSON.stringify(obj)}\n\n`);
+
+  try {
+    await userData.start();
+  } catch (e) {
+    send({ type: 'status', state: 'error', error: String(e) });
+  }
+
+  try {
+    const [account, openOrders, positions] = await Promise.all([
+      binance.send('GET', '/fapi/v2/account', {}, { signed: true }),
+      binance.send('GET', '/fapi/v1/openOrders', {}, { signed: true }),
+      binance.send('GET', '/fapi/v2/positionRisk', {}, { signed: true }),
+    ]);
+    send({ type: 'init', account, openOrders, positions });
+  } catch (e) {
+    send({ type: 'init', account: null, openOrders: [], positions: [], error: String(e) });
+  }
+
+  const onOrder = (data) => send({ type: 'order', ...data });
+  const onAccount = (data) => send({ type: 'account', ...data });
+  const onStatus = (data) => send({ type: 'status', ...data });
+
+  userData.on('user:order_trade_update', onOrder);
+  userData.on('user:account_update', onAccount);
+  userData.on('user:listenKey', onStatus);
+
+  const hb = setInterval(() => { res.write('event: ping\n\n'); }, 25000);
+
+  _req.on('close', () => {
+    clearInterval(hb);
+    userData.off('user:order_trade_update', onOrder);
+    userData.off('user:account_update', onAccount);
+    userData.off('user:listenKey', onStatus);
+    try { res.end(); } catch {}
+  });
+});
+
+export function userStreamRoutes(app) {
+  app.use(router);
+}


### PR DESCRIPTION
## Summary
- implement `userDataService` to manage Binance listen key, WebSocket and DB updates
- expose user data control endpoints under `/binance/user-data/*`
- stream normalized account and order events over SSE at `/live/user-stream`
- update live HTML page to display stream status, orders, account and positions

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test` *(fails: Missing TELEGRAM_BOT_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b05fa0288325a770addfe4c1b770