### PR TITLE
feat: add shared nav and footer

### DIFF
--- a/client/public/404.html
+++ b/client/public/404.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="/assets/nav.css">
+  <title>Not Found</title>
+</head>
+<body>
+<div id="app-nav"></div>
+<main style="padding:24px">
+  <h1>404 – nerasta</h1>
+  <p>Grįžti į <a href="/index.html">pagrindinį</a>.</p>
+</main>
+<div id="app-footer"></div>
+<script src="/assets/nav.js"></script>
+</body>
+</html>

--- a/client/public/analytics.html
+++ b/client/public/analytics.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <title>Analytics</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/assets/nav.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <style>
     body { font-family: system-ui, sans-serif; margin:20px; color:#111; background:#fafafa; }
@@ -22,6 +23,7 @@
   </style>
 </head>
 <body>
+  <div id="app-nav"></div>
   <h1>Analytics</h1>
   <div class="filters">
     <label>Symbol <input type="text" id="symbol" /></label>
@@ -241,6 +243,8 @@
 
   document.getElementById('apply').addEventListener('click', apply);
   loadStrategies().then(apply);
-</script>
+  </script>
+  <div id="app-footer"></div>
+  <script src="/assets/nav.js"></script>
 </body>
 </html>

--- a/client/public/assets/nav.css
+++ b/client/public/assets/nav.css
@@ -1,0 +1,22 @@
+:root { --bg:#0f1115; --fg:#e6e6e6; --muted:#9aa0a6; --acc:#4cc9f0; }
+body { margin:0; font-family:system-ui,Segoe UI,Roboto,Arial; color:var(--fg); background:var(--bg); }
+a { color:inherit; text-decoration:none; }
+
+.nav { display:flex; align-items:center; justify-content:space-between; padding:12px 16px; border-bottom:1px solid #222; position:sticky; top:0; background:var(--bg); z-index:100; }
+.nav__left { display:flex; align-items:center; gap:12px; }
+.nav__brand { font-weight:700; letter-spacing:.2px; }
+.nav__links { display:flex; gap:14px; }
+.nav__links a { padding:8px 10px; border-radius:10px; color:var(--muted); }
+.nav__links a.active, .nav__links a:hover { background:#1a1d24; color:#fff; }
+
+.nav__burger { display:none; font-size:20px; background:none; border:none; color:var(--fg); cursor:pointer; }
+
+.footer { margin-top:32px; padding:16px; border-top:1px solid #222; display:flex; gap:8px; align-items:center; color:var(--muted); font-size:14px; }
+.footer__spacer { opacity:.5; }
+
+/* Mobile */
+@media (max-width: 768px) {
+  .nav__links { display:none; flex-direction:column; gap:8px; position:absolute; top:56px; left:0; right:0; background:var(--bg); padding:8px 16px; border-bottom:1px solid #222; }
+  .nav__links.open { display:flex; }
+  .nav__burger { display:inline-block; }
+}

--- a/client/public/assets/nav.js
+++ b/client/public/assets/nav.js
@@ -1,0 +1,38 @@
+(async function() {
+  async function inject(selector, url) {
+    const host = document.querySelector(selector);
+    if (!host) return;
+    const res = await fetch(url, { cache: 'no-cache' });
+    host.innerHTML = await res.text();
+  }
+  await inject('#app-nav', '/partials/nav.html');
+  await inject('#app-footer', '/partials/footer.html');
+
+  const path = location.pathname.replace(/^\//,'').toLowerCase();
+  const map = {
+    'index.html': null,
+    'live.html': 'live',
+    'analytics.html': 'analytics',
+    'portfolio.html': 'portfolio',
+    'settings.html': 'settings'
+  };
+  const key = map[path] ?? (path ? path.split('.')[0] : null);
+  document.querySelectorAll('.nav__links a').forEach(a => {
+    if (a.dataset.link === key) a.classList.add('active');
+  });
+
+  const burger = document.querySelector('.nav__burger');
+  const links  = document.querySelector('.nav__links');
+  if (burger && links) {
+    burger.addEventListener('click', () => {
+      const open = links.classList.toggle('open');
+      burger.setAttribute('aria-expanded', String(open));
+    });
+  }
+
+  try {
+    const v = await fetch('/version', { cache:'no-cache' }).then(r=>r.json());
+    const el = document.getElementById('app-version');
+    if (el && v?.version) el.textContent = v.version + (v.commit ? ` (${v.commit.slice(0,7)})` : '');
+  } catch {}
+})();

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Crypto Signals</title>
+  <link rel="stylesheet" href="/assets/nav.css">
+</head>
+<body>
+  <div id="app-nav"></div>
+
+  <section style="padding:24px;">
+    <h1 style="margin:8px 0 16px;">Sveikas sugrįžęs 👋</h1>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px;">
+      <a class="card" href="/live.html">Live Monitoring →</a>
+      <a class="card" href="/analytics.html">Analytics Dashboard →</a>
+      <a class="card" href="/portfolio.html">Portfolio View →</a>
+      <a class="card" href="/settings.html">Settings / Presets →</a>
+    </div>
+  </section>
+  <style>
+  .card{display:block;padding:18px;border:1px solid #222;border-radius:14px;background:#111;}
+  .card:hover{border-color:#2a2f3a;background:#131720}
+  </style>
+
+  <div id="app-footer"></div>
+  <script src="/assets/nav.js"></script>
+</body>
+</html>

--- a/client/public/live.html
+++ b/client/public/live.html
@@ -3,9 +3,11 @@
 <head>
   <meta charset="utf-8">
   <title>Paper Trading Live</title>
+  <link rel="stylesheet" href="/assets/nav.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
+  <div id="app-nav"></div>
   <h1>Paper Trading</h1>
   <section id="risk">
     <h2>Risk</h2>
@@ -302,6 +304,7 @@ setInterval(loadClosedTrades, 30000);
     connect();
   })();
   </script>
+  </script>
 
   <script>
 (function() {
@@ -451,5 +454,7 @@ setInterval(loadClosedTrades, 30000);
   setInterval(refresh, 10000);
 })();
   </script>
+  <div id="app-footer"></div>
+  <script src="/assets/nav.js"></script>
 </body>
 </html>

--- a/client/public/partials/footer.html
+++ b/client/public/partials/footer.html
@@ -1,0 +1,5 @@
+<footer class="footer">
+  <span>Version: <span id="app-version">loading…</span></span>
+  <span class="footer__spacer">•</span>
+  <a href="https://github.com/your-org/crypto-signals" target="_blank" rel="noopener">GitHub</a>
+</footer>

--- a/client/public/partials/nav.html
+++ b/client/public/partials/nav.html
@@ -1,0 +1,12 @@
+<header class="nav">
+  <div class="nav__left">
+    <a class="nav__brand" href="/index.html">⚡️ Crypto Signals</a>
+    <button class="nav__burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
+  </div>
+  <nav class="nav__links">
+    <a href="/live.html"        data-link="live">Live</a>
+    <a href="/analytics.html"   data-link="analytics">Analytics</a>
+    <a href="/portfolio.html"   data-link="portfolio">Portfolio</a>
+    <a href="/settings.html"    data-link="settings">Settings</a>
+  </nav>
+</header>

--- a/client/public/portfolio.html
+++ b/client/public/portfolio.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <title>Portfolio</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/assets/nav.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <style>
     body { font-family: system-ui, sans-serif; margin:20px; color:#111; background:#fafafa; }
@@ -16,6 +17,7 @@
   </style>
 </head>
 <body>
+  <div id="app-nav"></div>
   <h1>Portfolio</h1>
   <div class="filters">
     <label>Symbol <input type="text" id="symbol" /></label>
@@ -88,6 +90,8 @@
 
   document.getElementById('apply').addEventListener('click', apply);
   apply();
-</script>
+  </script>
+  <div id="app-footer"></div>
+  <script src="/assets/nav.js"></script>
 </body>
 </html>

--- a/client/public/settings.html
+++ b/client/public/settings.html
@@ -3,8 +3,10 @@
 <head>
   <meta charset="utf-8">
   <title>Strategy Settings</title>
+  <link rel="stylesheet" href="/assets/nav.css">
 </head>
 <body>
+  <div id="app-nav"></div>
   <h1>Strategy Settings</h1>
   <div>Runner status: <span id="runnerStatus">...</span></div>
   <div id="strategies"></div>
@@ -148,6 +150,8 @@ document.getElementById('savePresetForm').onsubmit = async (e) => {
 };
 
 load();
-</script>
+  </script>
+  <div id="app-footer"></div>
+  <script src="/assets/nav.js"></script>
 </body>
 </html>

--- a/src/server.js
+++ b/src/server.js
@@ -500,14 +500,13 @@ app.get('/analytics/trades.csv', async (req, res) => {
   }
 });
 
-app.use('/analytics', express.static(publicDir));
 
 // Static files
-app.use(express.static(path.join(__dirname, '..', 'public')));
+app.use(express.static(publicDir));
 
-// SPA fallback — bet koks kitas GET, kuris nepateko į API/static, grąžina index.html
-app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
+// 404 fallback for any unmatched request
+app.use((req, res) => {
+  res.status(404).sendFile(path.join(publicDir, '404.html'));
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- add reusable navigation and footer partials for static pages
- highlight active page and support mobile menu with new nav.js and nav.css
- serve client/public as static root with 404 fallback

## Testing
- `npm test` *(fails: Cannot find module '/workspace/crypto-signals/test')*


------
https://chatgpt.com/codex/tasks/task_e_68a9eb0ba7a88325bed49646595397e3