### PR TITLE
feat: add accessible breadcrumbs and tab navigation

### DIFF
--- a/client/public/assets/ui-breadcrumbs.js
+++ b/client/public/assets/ui-breadcrumbs.js
@@ -10,7 +10,7 @@
   function buildCrumbs() {
     const host = document.getElementById('app-breadcrumbs');
     if (!host) return;
-    const path = location.pathname.split('/').pop() || 'index.html';
+    const path = (location.pathname.split('/').pop() || 'index.html').toLowerCase();
     const pageName = PAGE_NAMES[path] || document.title || 'Page';
     const tabLabel = document.querySelector('[role="tab"][aria-selected="true"]')?.textContent?.trim();
 
@@ -21,11 +21,12 @@
     ];
 
     host.innerHTML = parts.map((p,i)=>{
-      const isLast = i === parts.length-1;
-      const link = p.href && !isLast ? `<a href="${p.href}">${p.label}</a>` : `<span class="${isLast?'breadcrumbs__current':''}">${p.label}</span>`;
-      const sep = isLast ? '' : `<span class="breadcrumbs__sep">›</span>`;
+      const last = i === parts.length-1;
+      const link = p.href && !last ? `<a href="${p.href}">${p.label}</a>` : `<span class="${last?'breadcrumbs__current':''}">${p.label}</span>`;
+      const sep = last ? '' : `<span class="breadcrumbs__sep">›</span>`;
       return `${link}${sep}`;
     }).join('');
+
     if (tabLabel) document.title = `${tabLabel} — ${pageName} | Crypto Signals`;
   }
 

--- a/client/public/assets/ui-tabs.js
+++ b/client/public/assets/ui-tabs.js
@@ -48,7 +48,7 @@
     });
 
     const desired = parseDesiredTab() || localStorage.getItem(storageKey) || tabs[0].dataset.tab;
-    activate(desired, false);
+    activate(desired, /*push*/false);
   }
 
   document.addEventListener('DOMContentLoaded', ()=>{

--- a/client/public/partials/breadcrumbs.html
+++ b/client/public/partials/breadcrumbs.html
@@ -1,3 +1,1 @@
-<nav id="app-breadcrumbs" class="breadcrumbs" aria-label="Breadcrumb">
-  <!-- JS sugeneruos -->
-</nav>
+<nav id="app-breadcrumbs" class="breadcrumbs" aria-label="Breadcrumb"></nav>


### PR DESCRIPTION
## Summary
- add dynamic breadcrumbs partial and script
- implement accessible tabs with deep-linking and saved state

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f21c99d88325a2e313431a166a74