### PR TITLE
Add background job runner with API and UI

### DIFF
--- a/client/public/jobs.html
+++ b/client/public/jobs.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Jobs</title>
+  <link rel="stylesheet" href="/assets/nav.css">
+  <link rel="stylesheet" href="/assets/ui-breadcrumbs.css">
+  <style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #333; padding: 4px 8px; }
+    #log { background:#000; color:#0f0; padding:8px; height:200px; overflow:auto; white-space:pre-wrap; }
+    .progress { background:#222; height:10px; margin-top:4px; }
+    .progress > div { background:#0a0; height:100%; width:0; }
+  </style>
+</head>
+<body>
+  <div id="app-nav"></div>
+  <div id="app-breadcrumbs"></div>
+
+  <section style="padding:16px;">
+    <h1>Jobs</h1>
+
+    <h2>New Job</h2>
+    <form id="job-form">
+      <label>Type
+        <select id="job-type">
+          <option value="backtest">backtest</option>
+          <option value="optimize">optimize</option>
+          <option value="walkforward">walkforward</option>
+        </select>
+      </label>
+      <label>Params JSON
+        <textarea id="job-params" rows="4" cols="40">{"symbol":"BTCUSDT"}</textarea>
+      </label>
+      <button type="submit">Create</button>
+    </form>
+
+    <h2>Jobs</h2>
+    <table id="jobs-table">
+      <thead><tr><th>ID</th><th>Type</th><th>Status</th><th>Progress</th><th>Actions</th></tr></thead>
+      <tbody></tbody>
+    </table>
+
+    <div id="detail" style="margin-top:24px;display:none;">
+      <h2>Job Detail <span id="detail-id"></span></h2>
+      <div class="progress"><div id="detail-progress"></div></div>
+      <pre id="log"></pre>
+      <ul id="artifacts"></ul>
+    </div>
+  </section>
+
+  <script src="/assets/nav.js"></script>
+  <script src="/assets/ui-breadcrumbs.js"></script>
+  <script>
+    async function fetchJobs(){
+      const res = await fetch('/jobs');
+      const jobs = await res.json();
+      const tbody = document.querySelector('#jobs-table tbody');
+      tbody.innerHTML = jobs.map(j=>`<tr id="job-${j.id}"><td>${j.id}</td><td>${j.type}</td><td>${j.status}</td><td>${Math.round((j.progress||0)*100)}%</td><td><button data-view="${j.id}">view</button> <button data-cancel="${j.id}">cancel</button></td></tr>`).join('');
+    }
+    fetchJobs();
+
+    document.getElementById('job-form').addEventListener('submit', async e=>{
+      e.preventDefault();
+      const type = document.getElementById('job-type').value;
+      let params;
+      try { params = JSON.parse(document.getElementById('job-params').value||'{}'); } catch { alert('Bad JSON'); return; }
+      await fetch('/jobs',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({type,params})});
+      document.getElementById('job-params').value='{}';
+      fetchJobs();
+    });
+
+    document.querySelector('#jobs-table').addEventListener('click', async e=>{
+      if(e.target.dataset.view){ showDetail(Number(e.target.dataset.view)); }
+      if(e.target.dataset.cancel){ await fetch(`/jobs/${e.target.dataset.cancel}/cancel`,{method:'POST'}); }
+    });
+
+    let es; // EventSource for detail
+    async function showDetail(id){
+      const res = await fetch(`/jobs/${id}`);
+      const data = await res.json();
+      document.getElementById('detail-id').textContent = id;
+      document.getElementById('log').textContent = data.logs.map(l=>`[${l.level}] ${l.msg}`).join('\n');
+      document.getElementById('artifacts').innerHTML = data.artifacts.map(a=>`<li><a href="/jobs/${id}/artifacts/${a.id}/download">${a.label||a.kind}</a></li>`).join('');
+      document.getElementById('detail').style.display='block';
+      updateProgress(id, data.job.progress||0);
+      if(es) es.close();
+      es = new EventSource(`/jobs/stream?id=${id}`);
+      es.addEventListener('job', ev=>{ const j = JSON.parse(ev.data); updateProgress(id, j.progress||0); fetchJobs(); });
+      es.addEventListener('log', ev=>{ const l = JSON.parse(ev.data); const log = document.getElementById('log'); log.textContent += `\n[${l.level}] ${l.msg}`; log.scrollTop = log.scrollHeight; });
+    }
+
+    function updateProgress(id, p){
+      document.querySelector(`#job-${id} td:nth-child(4)`).textContent = Math.round(p*100)+"%";
+      document.getElementById('detail-progress').style.width = (p*100)+"%";
+    }
+
+    const esList = new EventSource('/jobs/stream');
+    esList.addEventListener('job', ev=>{
+      const j = JSON.parse(ev.data);
+      fetchJobs();
+      if(document.getElementById('detail').style.display !== 'none' && Number(document.getElementById('detail-id').textContent)===j.id){ updateProgress(j.id, j.progress||0); }
+    });
+  </script>
+</body>
+</html>

--- a/migrations/2025-08-job-runner.sql
+++ b/migrations/2025-08-job-runner.sql
@@ -1,0 +1,55 @@
+-- 1) Darbai (viena eilutė per užduotį)
+CREATE TABLE IF NOT EXISTS jobs (
+  id BIGSERIAL PRIMARY KEY,
+  type TEXT NOT NULL,                -- 'backtest' | 'optimize' | 'walkforward'
+  status TEXT NOT NULL DEFAULT 'queued', -- 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled'
+  priority INT NOT NULL DEFAULT 100, -- mažesnis = aukštesnis
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  queued_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  started_at TIMESTAMPTZ,
+  finished_at TIMESTAMPTZ,
+  progress REAL DEFAULT 0,           -- 0..1
+  params JSONB NOT NULL,             -- įvestis (symbol, strategy, date range, grid, WF config)
+  result JSONB,                      -- trumpa suvestinė (pvz., best metrics)
+  error TEXT                         -- klaidos pranešimas
+);
+CREATE INDEX IF NOT EXISTS idx_jobs_status_prio ON jobs(status, priority, id);
+CREATE INDEX IF NOT EXISTS idx_jobs_created ON jobs(created_at DESC);
+
+-- 2) Artefaktai (failų nuorodos)
+CREATE TABLE IF NOT EXISTS job_artifacts (
+  id BIGSERIAL PRIMARY KEY,
+  job_id BIGINT REFERENCES jobs(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL,                -- 'csv' | 'json' | 'png' | 'zip' | 'html'
+  label TEXT,
+  path TEXT NOT NULL,                -- pvz., /data/jobs/<id>/results.csv
+  size_bytes BIGINT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_job_artifacts_job ON job_artifacts(job_id);
+
+-- 3) Logai (stream’inimui real-time)
+CREATE TABLE IF NOT EXISTS job_logs (
+  id BIGSERIAL PRIMARY KEY,
+  job_id BIGINT REFERENCES jobs(id) ON DELETE CASCADE,
+  ts TIMESTAMPTZ NOT NULL DEFAULT now(),
+  level TEXT NOT NULL DEFAULT 'info',  -- info|warn|error
+  msg TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_job_logs_job_ts ON job_logs(job_id, ts);
+
+-- 4) Papildoma: statuso NOTIFY (SSE atnaujinimui)
+CREATE OR REPLACE FUNCTION notify_job_update() RETURNS trigger AS $$
+BEGIN
+  PERFORM pg_notify('job_update', NEW.id::text);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_jobs_notify ON jobs;
+CREATE TRIGGER trg_jobs_notify AFTER INSERT OR UPDATE ON jobs
+FOR EACH ROW EXECUTE FUNCTION notify_job_update();
+
+DROP TRIGGER IF EXISTS trg_job_logs_notify ON job_logs;
+CREATE TRIGGER trg_job_logs_notify AFTER INSERT ON job_logs
+FOR EACH ROW EXECUTE FUNCTION notify_job_update();

--- a/src/jobs/fs.js
+++ b/src/jobs/fs.js
@@ -1,0 +1,34 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { db } from '../storage/db.js';
+
+const ROOT = process.env.JOBS_DIR || '/mnt/data/jobs';
+
+export async function ensureJobDir(jobId) {
+  const dir = path.join(ROOT, String(jobId));
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+async function recordArtifact(jobId, kind, label, p) {
+  const stat = await fs.stat(p).catch(() => ({ size: 0 }));
+  await db.query(
+    'INSERT INTO job_artifacts(job_id, kind, label, path, size_bytes) VALUES ($1,$2,$3,$4,$5)',
+    [jobId, kind, label, p, stat.size]
+  );
+  return { path: p, size: stat.size };
+}
+
+export async function writeJSON(jobId, filename, data, label = null) {
+  const dir = await ensureJobDir(jobId);
+  const p = path.join(dir, filename);
+  await fs.writeFile(p, JSON.stringify(data, null, 2));
+  return recordArtifact(jobId, 'json', label, p);
+}
+
+export async function writeCSV(jobId, filename, csv, label = null) {
+  const dir = await ensureJobDir(jobId);
+  const p = path.join(dir, filename);
+  await fs.writeFile(p, csv);
+  return recordArtifact(jobId, 'csv', label, p);
+}

--- a/src/jobs/progress.js
+++ b/src/jobs/progress.js
@@ -1,0 +1,37 @@
+import { db } from '../storage/db.js';
+
+export async function log(jobId, level, msg) {
+  await db.query(
+    'INSERT INTO job_logs(job_id, level, msg) VALUES ($1,$2,$3)',
+    [jobId, level, msg]
+  );
+}
+
+export async function setProgress(jobId, p) {
+  await db.query('UPDATE jobs SET progress=$2 WHERE id=$1', [jobId, p]);
+}
+
+export async function markStatus(jobId, status, fields = {}) {
+  const sets = ['status=$2'];
+  const vals = [jobId, status];
+  let idx = 3;
+  if (fields.result !== undefined) {
+    sets.push(`result=$${idx}`);
+    vals.push(JSON.stringify(fields.result));
+    idx++;
+  }
+  if (fields.error !== undefined) {
+    sets.push(`error=$${idx}`);
+    vals.push(fields.error);
+    idx++;
+  }
+  if (status === 'running') sets.push('started_at=now()');
+  if (['succeeded', 'failed', 'canceled'].includes(status)) sets.push('finished_at=now()');
+  const sql = `UPDATE jobs SET ${sets.join(', ')} WHERE id=$1`;
+  await db.query(sql, vals);
+}
+
+export async function checkCanceled(jobId) {
+  const { rows } = await db.query('SELECT status FROM jobs WHERE id=$1', [jobId]);
+  return rows[0] && rows[0].status === 'canceled';
+}

--- a/src/jobs/runners/backtest.js
+++ b/src/jobs/runners/backtest.js
@@ -1,0 +1,18 @@
+import { writeCSV, writeJSON } from '../fs.js';
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+export async function run(job, { log, progress, signal }) {
+  log('info', `backtest start for ${job.params?.symbol || ''}`);
+  for (let i = 0; i < 5; i++) {
+    if (signal?.aborted) throw new Error('canceled');
+    await sleep(200);
+    progress((i + 1) / 5);
+    log('info', `step ${i + 1}`);
+  }
+  const tradesCsv = 'id,ts,side,qty,price\n';
+  await writeCSV(job.id, 'trades.csv', tradesCsv, 'Trades');
+  const result = { trades: 0 };
+  await writeJSON(job.id, 'stats.json', result, 'Stats');
+  return result;
+}

--- a/src/jobs/runners/optimize.js
+++ b/src/jobs/runners/optimize.js
@@ -1,0 +1,17 @@
+import { writeCSV, writeJSON } from '../fs.js';
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+export async function run(job, { log, progress, signal }) {
+  const total = 5;
+  for (let i = 0; i < total; i++) {
+    if (signal?.aborted) throw new Error('canceled');
+    await sleep(200);
+    progress((i + 1) / total);
+    log('info', `combo ${i + 1} / ${total}`);
+  }
+  await writeCSV(job.id, 'optimize_results.csv', 'params,metric\n', 'Optimize Results');
+  const result = { best: null };
+  await writeJSON(job.id, 'best_params.json', result, 'Best Params');
+  return result;
+}

--- a/src/jobs/runners/walkforward.js
+++ b/src/jobs/runners/walkforward.js
@@ -1,0 +1,17 @@
+import { writeCSV, writeJSON } from '../fs.js';
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+export async function run(job, { log, progress, signal }) {
+  const total = 5;
+  for (let i = 0; i < total; i++) {
+    if (signal?.aborted) throw new Error('canceled');
+    await sleep(200);
+    progress((i + 1) / total);
+    log('info', `window ${i + 1} / ${total}`);
+  }
+  await writeCSV(job.id, 'wf_oos_equity.csv', 'ts,equity\n', 'WF Equity');
+  const result = { windows: total };
+  await writeJSON(job.id, 'wf_summary.json', result, 'WF Summary');
+  return result;
+}

--- a/src/jobs/worker.js
+++ b/src/jobs/worker.js
@@ -1,0 +1,77 @@
+import { db } from '../storage/db.js';
+import { log, setProgress, markStatus, checkCanceled } from './progress.js';
+import * as fsh from './fs.js';
+import { run as runBacktest } from './runners/backtest.js';
+import { run as runOptimize } from './runners/optimize.js';
+import { run as runWalkforward } from './runners/walkforward.js';
+
+const RUNNERS = {
+  backtest: runBacktest,
+  optimize: runOptimize,
+  walkforward: runWalkforward,
+};
+
+async function claimNextJob(client) {
+  const { rows } = await client.query(`
+    UPDATE jobs
+    SET status='running', started_at=now()
+    WHERE id = (
+      SELECT id FROM jobs
+      WHERE status='queued'
+      ORDER BY priority ASC, id ASC
+      FOR UPDATE SKIP LOCKED
+      LIMIT 1
+    )
+    RETURNING *`);
+  return rows[0];
+}
+
+async function runJob(job) {
+  const runner = RUNNERS[job.type];
+  if (!runner) {
+    await markStatus(job.id, 'failed', { error: `unknown job type: ${job.type}` });
+    return;
+  }
+  const controller = new AbortController();
+  const cancelCheck = setInterval(async () => {
+    if (await checkCanceled(job.id)) controller.abort();
+  }, 1000);
+  try {
+    await log(job.id, 'info', `job ${job.id} started`);
+    const result = await runner(job, {
+      db,
+      fs: fsh,
+      log: (level, msg) => log(job.id, level, msg),
+      progress: (p) => setProgress(job.id, p),
+      signal: controller.signal,
+    });
+    await markStatus(job.id, 'succeeded', { result });
+  } catch (e) {
+    if (controller.signal.aborted) {
+      await markStatus(job.id, 'canceled');
+    } else {
+      await markStatus(job.id, 'failed', { error: e.message });
+    }
+  } finally {
+    clearInterval(cancelCheck);
+  }
+}
+
+export function startWorker() {
+  const interval = Number(process.env.JOB_WORKER_INTERVAL_MS || 2000);
+  const loop = async () => {
+    const client = await db.connect();
+    try {
+      const job = await claimNextJob(client);
+      if (job) {
+        await runJob(job);
+      }
+    } catch (e) {
+      console.error('worker loop error', e);
+    } finally {
+      client.release();
+      setTimeout(loop, interval);
+    }
+  };
+  loop();
+}

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -1,0 +1,116 @@
+import express from 'express';
+import path from 'path';
+import { db, listen } from '../storage/db.js';
+
+const router = express.Router();
+
+router.post('/jobs', async (req, res) => {
+  const { type, params, priority } = req.body || {};
+  if (!type || !params) return res.status(400).json({ error: 'invalid' });
+  const { rows } = await db.query(
+    'INSERT INTO jobs(type, params, priority) VALUES ($1,$2,$3) RETURNING *',
+    [type, JSON.stringify(params), priority || 100]
+  );
+  res.json(rows[0]);
+});
+
+router.get('/jobs', async (req, res) => {
+  const { type, status } = req.query;
+  const limit = Number(req.query.limit) || 50;
+  const offset = Number(req.query.offset) || 0;
+  const { rows } = await db.query(
+    `SELECT * FROM jobs
+     WHERE ($1::text IS NULL OR type=$1)
+       AND ($2::text IS NULL OR status=$2)
+     ORDER BY id DESC
+     LIMIT $3 OFFSET $4`,
+    [type || null, status || null, limit, offset]
+  );
+  res.json(rows);
+});
+
+router.get('/jobs/:id', async (req, res) => {
+  const id = Number(req.params.id);
+  const { rows: jobs } = await db.query('SELECT * FROM jobs WHERE id=$1', [id]);
+  if (!jobs.length) return res.status(404).json({ error: 'not_found' });
+  const job = jobs[0];
+  const { rows: artifacts } = await db.query('SELECT * FROM job_artifacts WHERE job_id=$1 ORDER BY id ASC', [id]);
+  const { rows: logs } = await db.query('SELECT * FROM job_logs WHERE job_id=$1 ORDER BY id DESC LIMIT 100', [id]);
+  res.json({ job, artifacts, logs });
+});
+
+router.post('/jobs/:id/cancel', async (req, res) => {
+  const id = Number(req.params.id);
+  await db.query(
+    `UPDATE jobs SET status='canceled' WHERE id=$1 AND status IN ('queued','running')`,
+    [id]
+  );
+  res.json({ ok: true });
+});
+
+router.get('/jobs/:id/logs', async (req, res) => {
+  const id = Number(req.params.id);
+  const since = Number(req.query.since) || 0;
+  const { rows } = await db.query(
+    `SELECT * FROM job_logs WHERE job_id=$1 AND id > $2 ORDER BY id ASC LIMIT 100`,
+    [id, since]
+  );
+  res.json(rows);
+});
+
+router.get('/jobs/:id/artifacts/:aid/download', async (req, res) => {
+  const id = Number(req.params.id);
+  const aid = Number(req.params.aid);
+  const { rows } = await db.query(
+    'SELECT path FROM job_artifacts WHERE job_id=$1 AND id=$2',
+    [id, aid]
+  );
+  if (!rows.length) return res.status(404).end();
+  const p = rows[0].path;
+  res.download(p, path.basename(p));
+});
+
+router.get('/jobs/stream', async (req, res) => {
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-store',
+    Connection: 'keep-alive',
+  });
+  res.flushHeaders?.();
+  const filterId = req.query.id ? Number(req.query.id) : null;
+
+  const sendUpdate = async (jobId) => {
+    const { rows: jobRows } = await db.query(
+      'SELECT id, status, progress FROM jobs WHERE id=$1',
+      [jobId]
+    );
+    if (jobRows[0]) {
+      res.write(`event: job\n` + `data: ${JSON.stringify(jobRows[0])}\n\n`);
+    }
+    const { rows: logRows } = await db.query(
+      'SELECT id, level, msg, ts FROM job_logs WHERE job_id=$1 ORDER BY id DESC LIMIT 1',
+      [jobId]
+    );
+    if (logRows[0]) {
+      res.write(`event: log\n` + `data: ${JSON.stringify(logRows[0])}\n\n`);
+    }
+  };
+
+  const release = await listen('job_update', async (payload) => {
+    const jobId = Number(payload);
+    if (filterId && jobId !== filterId) return;
+    await sendUpdate(jobId);
+  });
+
+  if (filterId) await sendUpdate(filterId);
+
+  req.on('close', () => {
+    release();
+  });
+});
+
+export function jobsRoutes(app) {
+  app.use(router);
+}
+
+export default { jobsRoutes };

--- a/src/server.js
+++ b/src/server.js
@@ -16,6 +16,7 @@ import { portfolioRoutes } from './routes/portfolio.js';
 import { riskRoutes } from './routes/risk.js';
 import { getStrategies } from './strategies/index.js';
 import { configRoutes } from './routes/config.js';
+import { jobsRoutes } from './routes/jobs.js';
 import binanceRoutes from './integrations/binance/routes.js';
 import healthRoutes from './routes/health.js';
 
@@ -41,6 +42,7 @@ userStreamRoutes(app);
 portfolioRoutes(app);
 riskRoutes(app);
 configRoutes(app);
+jobsRoutes(app);
 app.use('/binance', binanceRoutes);
 app.use('/', healthRoutes);
 
@@ -513,3 +515,7 @@ const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Server running on :${PORT}`);
 });
+
+if (process.env.ENABLE_JOB_WORKER === 'true') {
+  import('./jobs/worker.js').then(m => m.startWorker());
+}


### PR DESCRIPTION
## Summary
- add SQL schema for background jobs, artifacts, and logs
- implement job worker with stub runners and file helpers
- expose REST & SSE APIs and minimal frontend to manage jobs

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68aa25eeac508325b1ef2d9ace9b7bd6