### PR TITLE
feat: add job analytics overlays

### DIFF
--- a/src/routes/analytics.jobs.js
+++ b/src/routes/analytics.jobs.js
@@ -1,0 +1,45 @@
+import express from 'express';
+import { db } from '../storage/db.js';
+import { listArtifacts, fetchEquity, fetchTrades } from '../services/analyticsArtifacts.js';
+
+const router = express.Router();
+
+router.get('/analytics/jobs', async (req, res) => {
+  const { type, symbol, strategy } = req.query;
+  const limit = Number(req.query.limit) || 50;
+  const q = `
+    SELECT j.id, j.type, j.status, j.created_at, j.finished_at, j.result, j.params
+    FROM jobs j
+    WHERE j.status='succeeded'
+      AND ($1::text IS NULL OR j.type=$1)
+      AND ($2::text IS NULL OR (j.params->>'symbol')=$2)
+      AND ($3::text IS NULL OR (j.params->>'strategyId')=$3)
+    ORDER BY j.finished_at DESC NULLS LAST, j.id DESC
+    LIMIT $4`;
+  const { rows } = await db.query(q, [type || null, symbol || null, strategy || null, limit]);
+  const jobs = await Promise.all(rows.map(async j => {
+    const arts = await listArtifacts(j.id);
+    return { ...j, artifacts: arts };
+  }));
+  res.json({ jobs });
+});
+
+router.get('/analytics/job/:id/equity', async (req, res) => {
+  try {
+    const { equity, artifact } = await fetchEquity(req.params.id);
+    res.json({ equity, artifact });
+  } catch (e) {
+    res.status(404).json({ error: e.message });
+  }
+});
+
+router.get('/analytics/job/:id/trades', async (req, res) => {
+  try {
+    const { trades, artifact } = await fetchTrades(req.params.id);
+    res.json({ trades, artifact });
+  } catch (e) {
+    res.status(404).json({ error: e.message });
+  }
+});
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,8 @@ import { getStrategies } from './strategies/index.js';
 import { configRoutes } from './routes/config.js';
 import binanceRoutes from './integrations/binance/routes.js';
 import healthRoutes from './routes/health.js';
+import analyticsJobsRoutes from './routes/analytics.jobs.js';
+import { fetchEquity, fetchTrades } from './services/analyticsArtifacts.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicDir = path.join(__dirname, '..', 'client', 'public');
@@ -43,12 +45,69 @@ riskRoutes(app);
 configRoutes(app);
 app.use('/binance', binanceRoutes);
 app.use('/', healthRoutes);
+app.use('/', analyticsJobsRoutes);
 
 app.get('/strategies', (_req, res) => {
   res.json(getStrategies().map(s => ({ id: s.id, label: s.id.toUpperCase() })));
 });
 
 function bool(v) { return !!(v && String(v).length); }
+
+function computeStatsFromTrades(trades, fromMs = null, toMs = null) {
+  const equity = [];
+  const returns = [];
+  let eq = 10000;
+  let peak = eq;
+  let maxDD = 0;
+  for (const t of trades) {
+    const prevEq = eq;
+    eq += t.pnl || 0;
+    const ts = t.closed_at || t.ts_close || t.ts || null;
+    if (ts !== null) equity.push({ ts, equity: Number(eq.toFixed(2)) });
+    if (eq > peak) peak = eq;
+    const dd = (eq - peak) / peak;
+    if (dd < maxDD) maxDD = dd;
+    if (prevEq > 0) returns.push((eq - prevEq) / prevEq);
+  }
+
+  const avg = arr => arr.reduce((a, b) => a + b, 0) / (arr.length || 1);
+  const std = arr => {
+    if (arr.length <= 1) return 0;
+    const m = avg(arr);
+    return Math.sqrt(arr.reduce((a, b) => a + Math.pow(b - m, 2), 0) / (arr.length - 1));
+  };
+
+  const total = trades.length;
+  const wins = trades.filter(t => (t.pnl || 0) > 0);
+  const profit = wins.reduce((a, b) => a + (b.pnl || 0), 0);
+  const losses = trades.filter(t => (t.pnl || 0) < 0);
+  const loss = losses.reduce((a, b) => a + (b.pnl || 0), 0);
+  const avgPnL = total ? (profit + loss) / total : 0;
+  const avgPnLPct = total ? trades.reduce((a, b) => a + (b.pnl_pct || 0), 0) / total : 0;
+  const profitFactor = loss !== 0 ? profit / Math.abs(loss) : null;
+  const winRate = total ? wins.length / total : 0;
+  const sharpe = returns.length > 1 ? (avg(returns) / std(returns)) * Math.sqrt(252) : null;
+  const downside = returns.filter(r => r < 0);
+  const sortino = downside.length > 1 ? (avg(returns) / std(downside)) * Math.sqrt(252) : null;
+  const cagr = equity.length > 1 && fromMs && toMs && toMs > fromMs
+    ? Math.pow(equity[equity.length - 1].equity / 10000, 31557600000 / (toMs - fromMs)) - 1
+    : null;
+
+  return {
+    equity,
+    stats: {
+      totalTrades: total,
+      winRate,
+      avgPnL,
+      avgPnLPct,
+      profitFactor,
+      maxDrawdown: maxDD,
+      sharpe,
+      sortino,
+      cagr,
+    }
+  };
+}
 
 app.head('/health', (_req, res) => {
   res.set('Cache-Control', 'no-store');
@@ -349,55 +408,7 @@ app.get('/analytics', async (req, res) => {
     params: r.params || null,
   }));
 
-  const equity = [];
-  const returns = [];
-  let eq = 10000;
-  let peak = eq;
-  let maxDD = 0;
-  for (const t of closedTrades) {
-    const prevEq = eq;
-    eq += t.pnl || 0;
-    equity.push({ ts: t.closed_at, equity: Number(eq.toFixed(2)) });
-    if (eq > peak) peak = eq;
-    const dd = (eq - peak) / peak;
-    if (dd < maxDD) maxDD = dd;
-    if (prevEq > 0) returns.push((eq - prevEq) / prevEq);
-  }
-
-  const avg = arr => arr.reduce((a, b) => a + b, 0) / (arr.length || 1);
-  const std = arr => {
-    if (arr.length <= 1) return 0;
-    const m = avg(arr);
-    return Math.sqrt(arr.reduce((a, b) => a + Math.pow(b - m, 2), 0) / (arr.length - 1));
-  };
-
-  const total = closedTrades.length;
-  const wins = closedTrades.filter(t => (t.pnl || 0) > 0);
-  const profit = wins.reduce((a, b) => a + (b.pnl || 0), 0);
-  const losses = closedTrades.filter(t => (t.pnl || 0) < 0);
-  const loss = losses.reduce((a, b) => a + (b.pnl || 0), 0);
-  const avgPnL = total ? (profit + loss) / total : 0;
-  const avgPnLPct = total ? closedTrades.reduce((a, b) => a + (b.pnl_pct || 0), 0) / total : 0;
-  const profitFactor = loss !== 0 ? profit / Math.abs(loss) : null;
-  const winRate = total ? wins.length / total : 0;
-  const sharpe = returns.length > 1 ? (avg(returns) / std(returns)) * Math.sqrt(252) : null;
-  const downside = returns.filter(r => r < 0);
-  const sortino = downside.length > 1 ? (avg(returns) / std(downside)) * Math.sqrt(252) : null;
-  const cagr = equity.length > 1 && fromMs && toMs && toMs > fromMs
-    ? Math.pow(equity[equity.length - 1].equity / 10000, 31557600000 / (toMs - fromMs)) - 1
-    : null;
-
-  const stats = {
-    totalTrades: total,
-    winRate,
-    avgPnL,
-    avgPnLPct,
-    profitFactor,
-    maxDrawdown: maxDD,
-    sharpe,
-    sortino,
-    cagr,
-  };
+  const { equity, stats } = computeStatsFromTrades(closedTrades, fromMs, toMs);
 
   const q = new URLSearchParams();
   if (symbol) q.set('symbol', symbol);
@@ -406,6 +417,27 @@ app.get('/analytics', async (req, res) => {
   if (toMs) q.set('to', new Date(toMs).toISOString());
   if (paramsObj) q.set('params', JSON.stringify(paramsObj));
   const qs = q.toString();
+
+  let overlayEquity = null;
+  let overlayStats = null;
+  const overlayJobId = req.query.overlay_job_id ? Number(req.query.overlay_job_id) : null;
+  if (overlayJobId) {
+    try {
+      const { equity: oe } = await fetchEquity(overlayJobId);
+      overlayEquity = oe;
+    } catch (e) {
+      console.error('[analytics] overlay equity error:', e);
+    }
+    try {
+      const { trades: ot } = await fetchTrades(overlayJobId);
+      const { equity: tEq, stats: oStats } = computeStatsFromTrades(ot);
+      overlayStats = oStats;
+      if (!overlayEquity) overlayEquity = tEq;
+    } catch (e) {
+      if (!overlayStats) overlayStats = null;
+      console.error('[analytics] overlay trades error:', e);
+    }
+  }
 
   return res.json({
     filters: {
@@ -419,6 +451,8 @@ app.get('/analytics', async (req, res) => {
     equity,
     closedTrades,
     stats,
+    overlayEquity,
+    overlayStats,
     csv: {
       backtest: `/analytics/backtest.csv${qs ? `?${qs}` : ''}`,
       optimize: `/analytics/optimize.csv${qs ? `?${qs}` : ''}`,

--- a/src/services/analyticsArtifacts.js
+++ b/src/services/analyticsArtifacts.js
@@ -1,0 +1,105 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { db } from '../storage/db.js';
+
+// Simple in-memory cache for parsed CSV artifacts
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const csvCache = new Map(); // key: file path -> { mtimeMs, ts, rows }
+
+function parseCSV(str) {
+  const lines = str.trim().split(/\r?\n/);
+  const header = lines.shift()?.split(',').map(h => h.trim()) || [];
+  return lines.map(line => {
+    const cols = line.split(',');
+    const obj = {};
+    header.forEach((h, i) => {
+      obj[h] = (cols[i] || '').trim();
+    });
+    return obj;
+  });
+}
+
+export async function listArtifacts(jobId) {
+  const q = 'SELECT id, job_id, path, mime, size FROM job_artifacts WHERE job_id=$1 ORDER BY id';
+  const { rows } = await db.query(q, [jobId]);
+  return rows;
+}
+
+export async function readArtifactCSV(filePath) {
+  const abs = path.resolve(filePath);
+  const stat = await fs.stat(abs);
+  const cached = csvCache.get(abs);
+  if (cached && cached.mtimeMs === stat.mtimeMs && (Date.now() - cached.ts) < CACHE_TTL_MS) {
+    return cached.rows;
+  }
+  const data = await fs.readFile(abs, 'utf8');
+  const rows = parseCSV(data);
+  csvCache.set(abs, { mtimeMs: stat.mtimeMs, ts: Date.now(), rows });
+  return rows;
+}
+
+function parseTs(v) {
+  if (v === undefined || v === null || v === '') return null;
+  const n = Number(v);
+  if (!Number.isNaN(n)) {
+    // assume ms if large
+    if (n > 1e12) return n;
+    if (n > 1e9) return n * 1000;
+  }
+  const d = Date.parse(String(v));
+  return Number.isNaN(d) ? null : d;
+}
+
+export function normalizeEquity(rows) {
+  if (!rows.length) return [];
+  const cols = Object.keys(rows[0]);
+  const tsCol = cols.find(c => /^(ts|time|date)$/i.test(c)) || cols[0];
+  const eqCol = cols.find(c => /^(equity|balance)$/i.test(c)) || cols[1];
+  return rows.map(r => ({
+    ts: parseTs(r[tsCol]),
+    equity: r[eqCol] !== undefined ? Number(r[eqCol]) : null,
+  })).filter(r => r.ts !== null && r.equity !== null);
+}
+
+export function normalizeTrades(rows) {
+  if (!rows.length) return [];
+  const cols = Object.keys(rows[0]);
+  const find = (patterns, def) => {
+    const re = new RegExp(patterns.join('|'), 'i');
+    return cols.find(c => re.test(c)) || def;
+  };
+  const openCol = find(['ts_open', 'open_ts', 'opened', 'open_time', 'time_open', 'entry_ts']);
+  const closeCol = find(['ts_close', 'close_ts', 'closed', 'close_time', 'time_close', 'exit_ts']);
+  const sideCol = find(['side', 'direction', 'type']);
+  const qtyCol = find(['qty', 'quantity', 'amount', 'size']);
+  const entryCol = find(['entry', 'entry_price', 'open_price', 'price_in']);
+  const exitCol = find(['exit', 'exit_price', 'close_price', 'price_out']);
+  const pnlCol = find(['pnl', 'profit', 'pnl_value', 'pl']);
+  return rows.map(r => ({
+    ts_open: parseTs(r[openCol]),
+    ts_close: parseTs(r[closeCol]),
+    side: r[sideCol] || null,
+    qty: r[qtyCol] !== undefined ? Number(r[qtyCol]) : null,
+    entry: r[entryCol] !== undefined ? Number(r[entryCol]) : null,
+    exit: r[exitCol] !== undefined ? Number(r[exitCol]) : null,
+    pnl: r[pnlCol] !== undefined ? Number(r[pnlCol]) : null,
+  })).filter(t => t.ts_open !== null || t.ts_close !== null);
+}
+
+export async function fetchEquity(jobId) {
+  const arts = await listArtifacts(jobId);
+  const a = arts.find(x => /equity\.csv$|oos_equity\.csv$/i.test(x.path));
+  if (!a) throw new Error('equity artifact not found');
+  const rows = await readArtifactCSV(a.path);
+  const equity = normalizeEquity(rows);
+  return { equity, artifact: a };
+}
+
+export async function fetchTrades(jobId) {
+  const arts = await listArtifacts(jobId);
+  const a = arts.find(x => /trades\.csv$/i.test(x.path));
+  if (!a) throw new Error('trades artifact not found');
+  const rows = await readArtifactCSV(a.path);
+  const trades = normalizeTrades(rows);
+  return { trades, artifact: a };
+}


### PR DESCRIPTION
## Summary
- expose `/analytics/jobs` and job equity/trades APIs
- parse job artifacts with caching and normalization helpers
- allow `/analytics` to overlay job equity and stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa288712fc8325a0132f15e375a003