### PR TITLE
feat: add portfolio aggregation and view modules

### DIFF
--- a/client/public/assets/modules/portfolio/allocation.js
+++ b/client/public/assets/modules/portfolio/allocation.js
@@ -1,0 +1,49 @@
+/* eslint-env browser */
+/* global Toast */
+export async function mount(root){
+  root.innerHTML = `<div style="display:flex;gap:16px;flex-wrap:wrap;align-items:flex-start">
+    <div><canvas id="alloc-sym" width="360" height="360"></canvas></div>
+    <div><canvas id="alloc-str" width="360" height="360"></canvas></div>
+  </div>
+  <div style="margin-top:12px"><button id="alloc-refresh" class="btn">Refresh</button></div>
+  <div id="alloc-table" style="margin-top:12px"></div>`;
+
+  const Chart = window.Chart;
+  const c1 = root.querySelector('#alloc-sym').getContext('2d');
+  const c2 = root.querySelector('#alloc-str').getContext('2d');
+
+  async function load(){
+    const j = await fetch('/portfolio').then(r=>r.json());
+    const sym = j.allocation.bySymbol;
+    const str = j.allocation.byStrategy;
+
+    const pie = (ctx, labels, weights, title)=> new Chart(ctx, {
+      type:'doughnut',
+      data:{ labels, datasets:[{ data: weights }] },
+      options:{ plugins:{ legend:{ position:'bottom' }, title:{ display:true, text:title } } }
+    });
+
+    if (root._ch1) root._ch1.destroy();
+    if (root._ch2) root._ch2.destroy();
+    root._ch1 = pie(c1, sym.map(x=>x.symbol), sym.map(x=>+(x.weight*100).toFixed(2)), 'By Symbol (%)');
+    root._ch2 = pie(c2, str.map(x=>x.strategy), str.map(x=>+(x.weight*100).toFixed(2)), 'By Strategy (%)');
+
+    const rows = j.holdings.map(h=> `<tr>
+      <td>${h.symbol}</td><td>${h.qty}</td><td>${h.avg_entry.toFixed(6)}</td>
+      <td>${h.price.toFixed(6)}</td><td>${h.market_value.toFixed(2)}</td>
+      <td>${h.unrealized_pnl.toFixed(2)}</td>
+    </tr>`).join('');
+    root.querySelector('#alloc-table').innerHTML = `
+      <table class="tbl">
+        <thead><tr><th>Symbol</th><th>Qty</th><th>Avg Entry</th><th>Price</th><th>MV</th><th>Unrealized P&L</th></tr></thead>
+        <tbody>${rows || '<tr><td colspan="6" style="opacity:.6">No open positions</td></tr>'}</tbody>
+      </table>`;
+    const { gross, net, estVaR, largestWeight } = j.risk;
+    Toast.open({ title:'Portfolio updated', description:`Gross ${gross.toFixed(2)}, Net ${net.toFixed(2)}, VaR~${estVaR.toFixed(2)}, Max pos ${(largestWeight*100).toFixed(1)}%`, variant:'info', timeoutMs:3000 });
+  }
+
+  root.querySelector('#alloc-refresh').addEventListener('click', load);
+  await load();
+
+  return { unmount(){ try{ root._ch1?.destroy(); root._ch2?.destroy(); } catch{} } };
+}

--- a/client/public/assets/modules/portfolio/attribution.js
+++ b/client/public/assets/modules/portfolio/attribution.js
@@ -1,0 +1,44 @@
+/* eslint-env browser */
+export async function mount(root){
+  root.innerHTML = `<div style="display:flex;gap:8px;align-items:end;flex-wrap:wrap">
+    <label>From <input id="attr-from" type="date"></label>
+    <label>To <input id="attr-to" type="date"></label>
+    <label>Group by
+      <select id="attr-group">
+        <option value="symbol">Symbol</option>
+        <option value="strategy">Strategy</option>
+      </select>
+    </label>
+    <button id="attr-load" class="btn">Load</button>
+  </div>
+  <div style="margin-top:12px"><canvas id="attr-bar" height="300"></canvas></div>`;
+
+  const Chart = window.Chart;
+  const ctx = root.querySelector('#attr-bar').getContext('2d');
+
+  function toISODate(d){ return new Date(d).toISOString().slice(0,10); }
+  const today = new Date(); const from = new Date(today.getTime()-30*24*3600*1000);
+  root.querySelector('#attr-from').value = toISODate(from);
+  root.querySelector('#attr-to').value   = toISODate(today);
+
+  async function load(){
+    const f = root.querySelector('#attr-from').value;
+    const t = root.querySelector('#attr-to').value;
+    const g = root.querySelector('#attr-group').value;
+    const qs = new URLSearchParams({ from: new Date(f).toISOString(), to: new Date(t).toISOString(), groupBy: g });
+    const j = await fetch(`/portfolio/attribution?${qs}`).then(r=>r.json());
+
+    const labels = j.items.map(x=>x.key);
+    const data = j.items.map(x=>Number(x.pnl||0));
+    if (root._bar) root._bar.destroy();
+    root._bar = new Chart(ctx, {
+      type:'bar',
+      data:{ labels, datasets:[{ label:`P&L by ${j.groupBy}`, data }] },
+      options:{ plugins:{ legend:{ display:false } } }
+    });
+  }
+
+  root.querySelector('#attr-load').addEventListener('click', load);
+  await load();
+  return { unmount(){ try{ root._bar?.destroy(); }catch{} } };
+}

--- a/client/public/assets/modules/portfolio/correlation.js
+++ b/client/public/assets/modules/portfolio/correlation.js
@@ -1,0 +1,32 @@
+/* eslint-env browser */
+export async function mount(root){
+  root.innerHTML = `<div style="display:flex;gap:8px;align-items:center"><label>Window (days)
+    <input id="corr-window" type="number" min="5" max="120" value="30" style="width:80px"></label>
+    <button id="corr-load" class="btn">Load</button>
+  </div>
+  <div id="corr-heat" style="margin-top:12px;overflow:auto"></div>`;
+
+  async function load(){
+    const w = Number(root.querySelector('#corr-window').value||30);
+    const j = await fetch(`/portfolio/correlation?window=${w}`).then(r=>r.json());
+    const { symbols, matrix } = j;
+
+    if (!symbols.length){ root.querySelector('#corr-heat').innerHTML = '<div style="opacity:.7">No data</div>'; return; }
+
+    const tblHead = `<tr><th></th>${symbols.map(s=>`<th>${s}</th>`).join('')}</tr>`;
+    const rows = symbols.map((s,i)=>{
+      const tds = symbols.map((_,j)=>{
+        const v = matrix[i][j];
+        const c = v==null? '#111' : (v>=0 ? `rgba(6,214,160,${Math.abs(v)})` : `rgba(239,71,111,${Math.abs(v)})`);
+        const txt = v==null? '' : v.toFixed(2);
+        return `<td style="background:${c};text-align:center">${txt}</td>`;
+      }).join('');
+      return `<tr><th>${s}</th>${tds}</tr>`;
+    }).join('');
+    root.querySelector('#corr-heat').innerHTML = `<table class="tbl">${tblHead}${rows}</table>`;
+  }
+
+  root.querySelector('#corr-load').addEventListener('click', load);
+  await load();
+  return { unmount(){} };
+}

--- a/client/public/assets/modules/portfolio/risk.js
+++ b/client/public/assets/modules/portfolio/risk.js
@@ -1,0 +1,33 @@
+/* eslint-env browser */
+export async function mount(root){
+  root.innerHTML = `<div id="risk-cards" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px"></div>
+  <div style="margin-top:12px"><canvas id="risk-bars" height="280"></canvas></div>
+  <div style="margin-top:12px"><button id="risk-refresh" class="btn">Refresh</button></div>`;
+
+  const Chart = window.Chart;
+  const ctx = root.querySelector('#risk-bars').getContext('2d');
+
+  async function load(){
+    const j = await fetch('/portfolio').then(r=>r.json());
+    const { gross, net, estVaR, largestWeight } = j.risk;
+    const cards = [
+      ['Gross', gross.toFixed(2)],
+      ['Net', net.toFixed(2)],
+      ['Est. 1d VaR', estVaR.toFixed(2)],
+      ['Largest pos %', (largestWeight*100).toFixed(1)+'%']
+    ].map(([k,v])=> `<div class="card" style="padding:10px;border:1px solid #222;border-radius:10px"><div>${k}</div><b>${v}</b></div>`).join('');
+    root.querySelector('#risk-cards').innerHTML = cards;
+
+    const alloc = j.allocation.bySymbol;
+    if (root._bar) root._bar.destroy();
+    root._bar = new Chart(ctx, {
+      type:'bar',
+      data:{ labels: alloc.map(x=>x.symbol), datasets:[{ label:'Weight %', data: alloc.map(x=>+(x.weight*100).toFixed(2)) }] },
+      options:{ plugins:{ legend:{ display:false } }, scales:{ y:{ beginAtZero:true, ticks:{ callback:v=>v+'%' } } } }
+    });
+  }
+
+  root.querySelector('#risk-refresh').addEventListener('click', load);
+  await load();
+  return { unmount(){ try{ root._bar?.destroy(); }catch{} } };
+}

--- a/client/public/portfolio.html
+++ b/client/public/portfolio.html
@@ -14,16 +14,26 @@
   <main class="container">
     <div class="tabs" data-tabs id="portfolio-tabs">
       <div class="tablist" role="tablist" aria-label="Portfolio sections">
-        <button role="tab" id="tab-summary" data-tab="summary" aria-selected="true">Summary</button>
-        <button role="tab" id="tab-allocation" data-tab="allocation">Allocation</button>
+        <button role="tab" id="tab-alloc" data-tab="alloc" aria-selected="true">Allocation</button>
+        <button role="tab" id="tab-risk" data-tab="risk">Risk</button>
+        <button role="tab" id="tab-corr" data-tab="corr">Correlation</button>
+        <button role="tab" id="tab-attr" data-tab="attr">Attribution</button>
       </div>
 
-      <section role="tabpanel" id="panel-summary" data-tab-panel="summary" aria-labelledby="tab-summary">
-        <!-- summary -->
-      </section>
-      <section role="tabpanel" id="panel-allocation" data-tab-panel="allocation" aria-labelledby="tab-allocation" hidden>
-        <!-- allocation charts -->
-      </section>
+      <section role="tabpanel" id="panel-alloc" data-tab-panel="alloc" aria-labelledby="tab-alloc"
+        data-lazy-module="/assets/modules/portfolio/allocation.js"
+        data-lazy-vendor="/assets/vendor/chart.umd.js"></section>
+
+      <section role="tabpanel" id="panel-risk" data-tab-panel="risk" aria-labelledby="tab-risk"
+        data-lazy-module="/assets/modules/portfolio/risk.js"
+        data-lazy-vendor="/assets/vendor/chart.umd.js" hidden></section>
+
+      <section role="tabpanel" id="panel-corr" data-tab-panel="corr" aria-labelledby="tab-corr"
+        data-lazy-module="/assets/modules/portfolio/correlation.js" hidden></section>
+
+      <section role="tabpanel" id="panel-attr" data-tab-panel="attr" aria-labelledby="tab-attr"
+        data-lazy-module="/assets/modules/portfolio/attribution.js"
+        data-lazy-vendor="/assets/vendor/chart.umd.js" hidden></section>
     </div>
   </main>
 
@@ -31,5 +41,6 @@
   <script src="/assets/nav.js"></script>
   <script src="/assets/ui-breadcrumbs.js"></script>
   <script src="/assets/ui-tabs.js"></script>
+  <script src="/assets/ui-lazy.js"></script>
 </body>
 </html>

--- a/src/routes/portfolio.js
+++ b/src/routes/portfolio.js
@@ -1,155 +1,176 @@
 import express from 'express';
 import { db } from '../storage/db.js';
+import { latestPrices } from '../services/marketData.js';
 
 const router = express.Router();
 
-function parseDate(v) {
-  if (!v) return null;
-  const t = Date.parse(String(v));
-  return Number.isNaN(t) ? null : t;
+function daterangeDefaults(q) {
+  const to = q.to ? new Date(Number(q.to) || q.to) : new Date();
+  const from = q.from ? new Date(Number(q.from) || q.from) : new Date(to.getTime() - 30 * 24 * 3600 * 1000);
+  return { from, to };
 }
 
-function parseFilters(q) {
-  return {
-    symbol: (q.symbol || '').toString().trim() || null,
-    strategy: (q.strategy || '').toString().trim() || null,
-    from: parseDate(q.from),
-    to: parseDate(q.to),
-  };
-}
+router.get('/portfolio', async (req, res) => {
+  const { from, to } = daterangeDefaults(req.query);
 
-async function startingEquity() {
-  const { rows } = await db.query('SELECT balance_start FROM paper_state WHERE id=1');
-  return rows.length ? Number(rows[0].balance_start) : 10000;
-}
+  const openQ = await db.query(`
+    SELECT symbol,
+           COALESCE(SUM(CASE WHEN side='LONG' THEN qty ELSE -qty END),0) AS net_qty,
+           SUM(entry_price * qty * CASE WHEN side='LONG' THEN 1 ELSE -1 END) AS signed_notional,
+           COUNT(*) FILTER (WHERE closed_at IS NULL) AS legs
+    FROM paper_trades
+    WHERE closed_at IS NULL
+    GROUP BY symbol
+    HAVING ABS(COALESCE(SUM(CASE WHEN side='LONG' THEN qty ELSE -qty END),0)) > 0
+  `);
 
-async function loadAllocation(field, filters) {
-  const { symbol, strategy, from, to } = filters;
-  const cond = ["status='CLOSED'"];
-  const vals = [];
-  let i = 1;
-  if (symbol && field !== 'symbol') { cond.push(`symbol=$${i++}`); vals.push(symbol); }
-  if (strategy && field !== 'strategy') { cond.push(`strategy=$${i++}`); vals.push(strategy); }
-  if (from) { cond.push(`closed_at >= $${i++}`); vals.push(from); }
-  if (to) { cond.push(`closed_at <= $${i++}`); vals.push(to); }
-  const groupCol = field === 'strategy' ? 'strategy' : 'symbol';
-  const q = `SELECT ${groupCol} as k, SUM(pnl) as pnl FROM paper_trades WHERE ${cond.join(' AND ')} GROUP BY ${groupCol}`;
-  const { rows } = await db.query(q, vals);
-  return rows.map(r => ({ [field]: r.k, pnl: Number(r.pnl || 0) }));
-}
-
-function normalizeAllocation(arr, key) {
-  const total = arr.reduce((s, r) => s + Math.abs(r.pnl), 0);
-  return total ? arr.map(r => ({ [key]: r[key], value: Math.abs(r.pnl) / total })) : [];
-}
-
-async function loadRisk(filters) {
-  const { symbol, strategy } = filters;
-  const cond = ["status='OPEN'"];
-  const vals = [];
-  let i = 1;
-  if (symbol) { cond.push(`symbol=$${i++}`); vals.push(symbol); }
-  if (strategy) { cond.push(`strategy=$${i++}`); vals.push(strategy); }
-  const q = `SELECT symbol, strategy, COALESCE(risk_pct,0) as risk_pct FROM paper_trades WHERE ${cond.join(' AND ')}`;
-  const { rows } = await db.query(q, vals);
-  const exposure = rows.map(r => ({ symbol: r.symbol, strategy: r.strategy, riskPct: Number(r.risk_pct) }));
-  const totalRiskPct = exposure.reduce((s, r) => s + r.riskPct, 0);
-  return { exposure, totalRiskPct };
-}
-
-router.get('/', async (req, res) => {
-  res.set('Cache-Control', 'no-store');
-  const filters = parseFilters(req.query);
-  try {
-    const [byStrategy, bySymbol] = await Promise.all([
-      loadAllocation('strategy', filters),
-      loadAllocation('symbol', filters),
-    ]);
-    const totalPnL = byStrategy.reduce((s, r) => s + r.pnl, 0);
-    const eq = (await startingEquity()) + totalPnL;
-    const allocation = {
-      byStrategy: normalizeAllocation(byStrategy, 'strategy'),
-      bySymbol: normalizeAllocation(bySymbol, 'symbol'),
+  const symbols = openQ.rows.map(r => r.symbol);
+  const prices = await latestPrices(symbols);
+  const holdings = openQ.rows.map(r => {
+    const qty = Number(r.net_qty);
+    const mkt = (prices[r.symbol] || 0) * qty;
+    const avgEntry = qty !== 0 ? Number(r.signed_notional) / qty : 0;
+    const price = prices[r.symbol] || 0;
+    const unrealized = (price - avgEntry) * qty;
+    return {
+      symbol: r.symbol,
+      qty,
+      avg_entry: avgEntry,
+      price,
+      market_value: mkt,
+      unrealized_pnl: unrealized
     };
-    const attribution = {
-      byStrategy: byStrategy.map(r => ({ strategy: r.strategy, pnl: r.pnl, pct: totalPnL ? r.pnl / totalPnL : 0 })),
-      bySymbol: bySymbol.map(r => ({ symbol: r.symbol, pnl: r.pnl, pct: totalPnL ? r.pnl / totalPnL : 0 })),
-    };
-    const risk = await loadRisk(filters);
-    const correlation = { symbols: [], matrix: [] }; // TODO
-    const summary = { equity: eq, totalPnL, maxDrawdown: null, profitFactor: null, sharpe: null, sortino: null };
-    const csvBase = '/csv';
-    res.json({
-      filters,
-      summary,
-      allocation,
-      risk,
-      correlation,
-      attribution,
-      csv: {
-        allocation: `${csvBase}/portfolio_allocation.csv`,
-        attribution: `${csvBase}/portfolio_attribution.csv`,
-        correlation: `${csvBase}/portfolio_correlation.csv`,
-      },
-    });
-  } catch (e) {
-    console.error('[/portfolio] error:', e);
-    res.status(500).json({ ok: false, error: 'db_error' });
-  }
+  });
+
+  const totalMV = holdings.reduce((s, h) => s + Math.abs(h.market_value), 0) || 0;
+  const allocBySymbol = holdings.map(h => ({
+    symbol: h.symbol,
+    weight: totalMV ? Math.abs(h.market_value) / totalMV : 0
+  })).sort((a, b) => b.weight - a.weight);
+
+  const stratQ = await db.query(`
+    SELECT COALESCE(strategy, 'default') AS strategy,
+           SUM((CASE WHEN side='LONG' THEN 1 ELSE -1 END) * qty * (SELECT close FROM candles c WHERE c.symbol=pt.symbol ORDER BY ts DESC LIMIT 1)) AS signed_mv
+    FROM paper_trades pt
+    WHERE closed_at IS NULL
+    GROUP BY strategy
+  `);
+  const totalStrat = stratQ.rows.reduce((s, r) => s + Math.abs(Number(r.signed_mv || 0)), 0) || 0;
+  const allocByStrategy = stratQ.rows.map(r => ({
+    strategy: r.strategy,
+    weight: totalStrat ? Math.abs(Number(r.signed_mv || 0)) / totalStrat : 0
+  })).sort((a, b) => b.weight - a.weight);
+
+  const attrSym = await db.query(`
+    SELECT symbol, SUM(pnl) AS pnl
+    FROM paper_trades
+    WHERE closed_at BETWEEN $1 AND $2
+    GROUP BY symbol
+    ORDER BY SUM(pnl) DESC
+  `, [from, to]);
+  const attrStr = await db.query(`
+    SELECT COALESCE(strategy,'default') AS strategy, SUM(pnl) AS pnl
+    FROM paper_trades
+    WHERE closed_at BETWEEN $1 AND $2
+    GROUP BY strategy
+    ORDER BY SUM(pnl) DESC
+  `, [from, to]);
+
+  const retQ = await db.query(`
+    WITH r AS (
+      SELECT symbol,
+             (close / LAG(close) OVER (PARTITION BY symbol ORDER BY ts) - 1) AS ret
+      FROM candles
+      WHERE ts >= (extract(epoch from now())*1000 - 30*24*3600*1000)
+    )
+    SELECT symbol, STDDEV_POP(ret) AS sigma
+    FROM r WHERE ret IS NOT NULL GROUP BY symbol
+  `);
+  const sigma = Object.fromEntries(retQ.rows.map(r => [r.symbol, Number(r.sigma || 0)]));
+
+  const gross = holdings.reduce((s, h) => s + Math.abs(h.market_value), 0);
+  const net = holdings.reduce((s, h) => s + h.market_value, 0);
+  const z = 1.65;
+  const estVaR = holdings.reduce((s, h) => {
+    const v = Math.abs(h.market_value);
+    const sgm = sigma[h.symbol] || 0;
+    return s + z * sgm * v;
+  }, 0);
+  const largest = totalMV ? Math.max(0, ...allocBySymbol.map(a => a.weight)) : 0;
+
+  res.json({
+    asOf: Date.now(),
+    holdings,
+    allocation: { bySymbol: allocBySymbol, byStrategy: allocByStrategy },
+    risk: { gross, net, estVaR, largestWeight: largest },
+    attribution: { bySymbol: attrSym.rows, byStrategy: attrStr.rows },
+    correlation: { windowDays: 30 }
+  });
 });
 
-async function csvAllocationHandler(req, res) {
-  const filters = parseFilters(req.query);
-  try {
-    const [byStrategy, bySymbol] = await Promise.all([
-      loadAllocation('strategy', filters),
-      loadAllocation('symbol', filters),
-    ]);
-    const lines = ['type,key,pnl'];
-    byStrategy.forEach(r => lines.push(['strategy', r.strategy, r.pnl].join(',')));
-    bySymbol.forEach(r => lines.push(['symbol', r.symbol, r.pnl].join(',')));
-    res.set('Content-Type', 'text/csv; charset=utf-8');
-    res.set('Cache-Control', 'no-store');
-    res.send(lines.join('\n'));
-  } catch (e) {
-    console.error('[/csv/portfolio_allocation] error:', e);
-    res.status(500).send('db_error');
-  }
-}
+router.get('/portfolio/correlation', async (req, res) => {
+  const window = Math.max(5, Math.min(120, Number(req.query.window) || 30));
+  const base = await db.query(`
+    SELECT symbol, SUM(volume) AS vol
+    FROM candles
+    WHERE ts >= (SELECT MAX(ts) FROM candles) - $1::bigint * 24*3600*1000
+    GROUP BY symbol
+    ORDER BY SUM(volume) DESC
+    LIMIT 12
+  `, [window]);
+  const symbols = base.rows.map(r => r.symbol);
+  if (!symbols.length) return res.json({ symbols: [], matrix: [] });
 
-async function csvAttributionHandler(req, res) {
-  const filters = parseFilters(req.query);
-  try {
-    const [byStrategy, bySymbol] = await Promise.all([
-      loadAllocation('strategy', filters),
-      loadAllocation('symbol', filters),
-    ]);
-    const total = [...byStrategy, ...bySymbol].reduce((s, r) => s + r.pnl, 0) || 0;
-    const lines = ['type,key,pnl,pct'];
-    byStrategy.forEach(r => lines.push(['strategy', r.strategy, r.pnl, total ? r.pnl/total : 0].join(',')));
-    bySymbol.forEach(r => lines.push(['symbol', r.symbol, r.pnl, total ? r.pnl/total : 0].join(',')));
-    res.set('Content-Type', 'text/csv; charset=utf-8');
-    res.set('Cache-Control', 'no-store');
-    res.send(lines.join('\n'));
-  } catch (e) {
-    console.error('[/csv/portfolio_attribution] error:', e);
-    res.status(500).send('db_error');
-  }
-}
+  const retQ = await db.query(`
+    SELECT symbol,
+           (close / LAG(close) OVER (PARTITION BY symbol ORDER BY ts) - 1) AS ret
+    FROM candles
+    WHERE symbol = ANY($1)
+      AND ts >= (SELECT MAX(ts) FROM candles) - $2::bigint * 24*3600*1000
+    ORDER BY symbol, ts
+  `, [symbols, window]);
 
-async function csvCorrelationHandler(_req, res) {
-  // Placeholder empty CSV
-  const lines = ['symbol1,symbol2,correlation'];
-  res.set('Content-Type', 'text/csv; charset=utf-8');
-  res.set('Cache-Control', 'no-store');
-  res.send(lines.join('\n'));
-}
+  const bySym = new Map(symbols.map(s => [s, []]));
+  retQ.rows.forEach(r => { if (r.ret != null) bySym.get(r.symbol).push(Number(r.ret)); });
+
+  function pearson(a, b) {
+    const n = Math.min(a.length, b.length);
+    if (n < 5) return null;
+    let sa = 0, sb = 0, sab = 0, saa = 0, sbb = 0;
+    for (let i = 0; i < n; i++) { const x = a[i], y = b[i]; sa += x; sb += y; sab += x * y; saa += x * x; sbb += y * y; }
+    const cov = sab / n - (sa / n) * (sb / n);
+    const va = saa / n - (sa / n) * (sa / n);
+    const vb = sbb / n - (sb / n) * (sb / n);
+    const den = Math.sqrt(va * vb);
+    return den > 0 ? cov / den : null;
+  }
+
+  const matrix = symbols.map(() => Array(symbols.length).fill(null));
+  for (let i = 0; i < symbols.length; i++) {
+    for (let j = i; j < symbols.length; j++) {
+      const r = pearson(bySym.get(symbols[i]), bySym.get(symbols[j]));
+      matrix[i][j] = matrix[j][i] = (r == null ? null : Number(r.toFixed(4)));
+    }
+  }
+  res.json({ symbols, matrix, windowDays: window });
+});
+
+router.get('/portfolio/attribution', async (req, res) => {
+  const { from, to } = daterangeDefaults(req.query);
+  const groupBy = (req.query.groupBy === 'strategy') ? 'strategy' : 'symbol';
+  const col = groupBy === 'strategy' ? "COALESCE(strategy,'default')" : 'symbol';
+  const { rows } = await db.query(`
+    SELECT ${col} AS key, SUM(pnl) AS pnl, COUNT(*) AS n
+    FROM paper_trades
+    WHERE closed_at BETWEEN $1 AND $2
+    GROUP BY ${col}
+    ORDER BY SUM(pnl) DESC
+  `, [from, to]);
+  res.json({ groupBy, items: rows });
+});
 
 export function portfolioRoutes(app) {
-  app.use('/portfolio', router);
-  app.get('/csv/portfolio_allocation.csv', csvAllocationHandler);
-  app.get('/csv/portfolio_attribution.csv', csvAttributionHandler);
-  app.get('/csv/portfolio_correlation.csv', csvCorrelationHandler);
+  app.use(router);
 }
 
 export default router;

--- a/src/services/marketData.js
+++ b/src/services/marketData.js
@@ -1,0 +1,21 @@
+import { db } from '../storage/db.js';
+
+export async function latestPrices(symbols = []) {
+  if (symbols.length === 0) {
+    const { rows } = await db.query(`
+      SELECT DISTINCT ON (symbol) symbol, close AS price, ts
+      FROM candles
+      ORDER BY symbol, ts DESC
+    `);
+    return Object.fromEntries(rows.map(r => [r.symbol, Number(r.price)]));
+  }
+  const { rows } = await db.query(`
+      SELECT DISTINCT ON (symbol) symbol, close AS price, ts
+      FROM candles
+      WHERE symbol = ANY($1)
+      ORDER BY symbol, ts DESC
+    `, [symbols]);
+  return Object.fromEntries(rows.map(r => [r.symbol, Number(r.price)]));
+}
+
+export default { latestPrices };


### PR DESCRIPTION
## Summary
- add market data helper for latest prices
- implement portfolio endpoints with allocation, risk, correlation and attribution
- build portfolio dashboard tabs with allocation, risk, correlation and attribution modules

## Testing
- `npm test` (fails: test failed)
- `npm run lint` (fails: existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68adda1e39148325b63c7064617838ef