### PR TITLE
feat: add frontend observability and RUM metrics

### DIFF
--- a/assets/http.js
+++ b/assets/http.js
@@ -1,0 +1,39 @@
+import CorrelationBar from './obs/correlation-bar.js';
+import { showErrorToast } from './obs/error-toasts.js';
+
+export async function http(url, { method = 'GET', headers = {}, body } = {}) {
+  const start = performance.now();
+  const h = { ...headers };
+  if (!h['x-request-id']) {
+    h['x-request-id'] = (self.crypto?.randomUUID?.() || Math.random().toString(36).slice(2));
+  }
+  let res;
+  try {
+    res = await fetch(url, { method, headers: h, body });
+  } catch (e) {
+    const errMeta = { message: `Network error ${method} ${url}`, code: 'NETWORK_ERROR' };
+    CorrelationBar?.pushError(errMeta);
+    showErrorToast(errMeta);
+    throw e;
+  }
+  const duration = performance.now() - start;
+
+  const reqId = res.headers.get('x-request-id');
+  const traceparent = res.headers.get('traceparent');
+  const traceId = parseTrace(traceparent);
+
+  if (!res.ok) {
+    const msg = `HTTP ${res.status} ${method} ${url}`;
+    const errMeta = { message: msg, reqId, code: 'HTTP_ERROR', httpStatus: res.status, traceId };
+    CorrelationBar?.pushError(errMeta);
+    showErrorToast(errMeta);
+    throw new Error(msg);
+  }
+
+  CorrelationBar?.pushEvent({ type: 'http', reqId, traceId, ts: Date.now() });
+  return res;
+}
+
+function parseTrace(tp) {
+  return tp?.split('-')?.[1];
+}

--- a/assets/obs/correlation-bar.css
+++ b/assets/obs/correlation-bar.css
@@ -1,0 +1,5 @@
+.correlation-bar{position:fixed;top:0;right:0;background:rgba(0,0,0,.7);color:#fff;padding:4px;font-size:12px;z-index:9999;font-family:sans-serif}
+.correlation-bar ul{list-style:none;margin:0;padding:0}
+.correlation-bar li{display:flex;gap:4px;align-items:center;margin-bottom:2px}
+.correlation-bar .id{cursor:pointer;text-decoration:underline}
+.correlation-bar .type{font-weight:bold}

--- a/assets/obs/correlation-bar.js
+++ b/assets/obs/correlation-bar.js
@@ -1,0 +1,49 @@
+const CorrelationBar = (() => {
+  let enabled = false;
+  let events = [];
+  let container, list;
+
+  function init({ enabled: en = true, env } = {}) {
+    const params = new URLSearchParams(location.search);
+    if (params.get('debug') === '1') en = true;
+    enabled = en;
+    if (!enabled) return;
+    container = document.createElement('div');
+    container.className = 'correlation-bar';
+    container.innerHTML = '<ul></ul>';
+    list = container.querySelector('ul');
+    document.body.appendChild(container);
+  }
+
+  function push(arr, item, max) {
+    arr.push(item);
+    if (arr.length > max) arr.shift();
+  }
+
+  function render() {
+    if (!enabled || !list) return;
+    list.innerHTML = events.map(e => {
+      const req = e.reqId ? `<span class="id" data-copy="${e.reqId}">req</span>` : '';
+      const trace = e.traceId ? `<span class="id" data-copy="${e.traceId}">trace</span>` : '';
+      return `<li><span class="type">${e.type}</span>${req}${trace}</li>`;
+    }).join('');
+    list.querySelectorAll('[data-copy]').forEach(el => {
+      el.onclick = () => navigator.clipboard?.writeText(el.dataset.copy);
+    });
+  }
+
+  function pushEvent(ev) {
+    if (!enabled) return;
+    push(events, ev, 5);
+    render();
+  }
+
+  function pushError(err) {
+    pushEvent({ type: 'error', ...err });
+  }
+
+  return { init, pushEvent, pushError };
+})();
+
+window.CorrelationBar = CorrelationBar;
+export default CorrelationBar;

--- a/assets/obs/error-toasts.js
+++ b/assets/obs/error-toasts.js
@@ -1,0 +1,30 @@
+let container;
+
+function ensureContainer() {
+  if (container) return;
+  container = document.createElement('div');
+  container.style.position = 'fixed';
+  container.style.bottom = '10px';
+  container.style.right = '10px';
+  container.style.zIndex = '10000';
+  document.body.appendChild(container);
+}
+
+export function showErrorToast(meta = {}) {
+  ensureContainer();
+  const code = meta.reqId || `corr-${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  const toast = document.createElement('div');
+  toast.style.background = 'rgba(0,0,0,0.8)';
+  toast.style.color = '#fff';
+  toast.style.padding = '8px';
+  toast.style.marginTop = '4px';
+  toast.style.fontSize = '12px';
+  toast.innerHTML = `<div>${meta.message || 'Error'}<br/>Incident: <span class="code">${code}</span></div>
+<button class="copy">Copy incident code</button>
+${meta.reqId ? '<button class="details">View details</button>' : ''}`;
+  toast.querySelector('.copy').onclick = () => navigator.clipboard?.writeText(code);
+  const details = toast.querySelector('.details');
+  if (details) details.onclick = () => alert(JSON.stringify(meta, null, 2));
+  container.appendChild(toast);
+  setTimeout(() => toast.remove(), 5000);
+}

--- a/assets/obs/net-inspector.js
+++ b/assets/obs/net-inspector.js
@@ -1,0 +1,46 @@
+export function initNetInspector() {
+  const params = new URLSearchParams(location.search);
+  const dev = params.get('debug') === '1' || process.env.NODE_ENV === 'development';
+  if (!dev) return;
+  const panel = document.createElement('div');
+  panel.style.position = 'fixed';
+  panel.style.bottom = '0';
+  panel.style.left = '0';
+  panel.style.right = '0';
+  panel.style.maxHeight = '200px';
+  panel.style.overflow = 'auto';
+  panel.style.background = 'rgba(0,0,0,0.9)';
+  panel.style.color = '#0f0';
+  panel.style.fontSize = '12px';
+  panel.style.display = 'none';
+  panel.style.zIndex = '9999';
+  document.body.appendChild(panel);
+
+  let reqs = [];
+  function render() {
+    panel.innerHTML = reqs.map(r => `<div>[${r.method}] ${r.url} ${r.status} ${r.duration.toFixed(0)}ms reqId=${r.reqId || ''} traceId=${r.traceId || ''} <button data-curl="${r.curl}">copy</button></div>`).join('');
+    panel.querySelectorAll('button').forEach(b => b.onclick = () => navigator.clipboard?.writeText(b.dataset.curl));
+  }
+
+  const origFetch = window.fetch;
+  window.fetch = async (input, init = {}) => {
+    const method = init.method || 'GET';
+    const start = performance.now();
+    const res = await origFetch(input, init);
+    const duration = performance.now() - start;
+    const reqId = res.headers.get('x-request-id');
+    const traceparent = res.headers.get('traceparent');
+    const traceId = traceparent?.split('-')[1];
+    const curl = `curl -X ${method} '${input}'${reqId ? ` -H 'x-request-id: ${reqId}'` : ''}`;
+    reqs.push({ method, url: input, status: res.status, duration, reqId, traceId, curl });
+    if (reqs.length > 10) reqs.shift();
+    render();
+    return res;
+  };
+
+  document.addEventListener('keydown', e => {
+    if (e.ctrlKey && e.key === '`') {
+      panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+    }
+  });
+}

--- a/assets/obs/rum.js
+++ b/assets/obs/rum.js
@@ -1,0 +1,26 @@
+function send(payload, path = '/rum/metrics') {
+  const blob = new Blob([JSON.stringify(payload)], { type: 'application/json' });
+  if (!(navigator.sendBeacon && navigator.sendBeacon(path, blob))) {
+    fetch(path, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+  }
+}
+
+export function initRUM() {
+  const perf = performance;
+  const nav = perf.getEntriesByType('navigation')[0];
+  if (nav) {
+    send({ ttfb: nav.responseStart / 1000, dcl: nav.domContentLoadedEventEnd / 1000, load: nav.loadEventEnd / 1000, type: 'navigation' });
+  }
+
+  new PerformanceObserver((list) => {
+    for (const e of list.getEntries()) {
+      if (e.name === 'first-contentful-paint') send({ fcp: e.startTime / 1000, type: 'paint' });
+      if (e.name === 'largest-contentful-paint') send({ lcp: e.startTime / 1000, type: 'paint' });
+    }
+  }).observe({ type: 'paint', buffered: true });
+
+  new PerformanceObserver((list) => {
+    const items = list.getEntries();
+    send({ longtasks: items.length, longtaskMaxMs: Math.max(0, ...items.map(i => i.duration)), type: 'longtask' });
+  }).observe({ type: 'longtask', buffered: true });
+}

--- a/assets/sse.js
+++ b/assets/sse.js
@@ -1,13 +1,55 @@
-const es = new EventSource('/events');
+import CorrelationBar from './obs/correlation-bar.js';
+import { showErrorToast } from './obs/error-toasts.js';
 
-es.onmessage = evt => {
-  try {
-    const data = JSON.parse(evt.data);
-    console.log('event', evt.type, data);
-    window.debugLastEvent = data;
-  } catch (e) {
-    console.error('bad event', e);
+let es;
+let reconnects = 0;
+let connectedAt = 0;
+
+function pickMeta(d) {
+  return { reqId: d.reqId, traceId: d.traceId, jobId: d.jobId, jobType: d.jobType };
+}
+
+function sendSseStats(disconnectTs) {
+  const connectedSec = connectedAt ? Math.round((disconnectTs - connectedAt) / 1000) : 0;
+  const payload = { connectedSeconds: connectedSec, reconnectAttempts: reconnects };
+  const blob = new Blob([JSON.stringify(payload)], { type: 'application/json' });
+  if (!(navigator.sendBeacon && navigator.sendBeacon('/rum/sse', blob))) {
+    fetch('/rum/sse', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
   }
-};
+}
 
-es.onerror = err => console.error('sse error', err);
+function connect() {
+  es = new EventSource('/events');
+  es.onopen = () => {
+    connectedAt = Date.now();
+    reconnects = 0;
+    CorrelationBar?.pushEvent({ type: 'sse-open', ts: connectedAt });
+  };
+  es.onerror = () => {
+    const now = Date.now();
+    es.close();
+    sendSseStats(now);
+    reconnects++;
+    CorrelationBar?.pushError({ message: 'SSE disconnected', code: 'SSE_DISCONNECT' });
+    showErrorToast({ message: 'SSE disconnected', code: 'SSE_DISCONNECT' });
+    const delay = Math.min(30000, Math.random() * (1000 * (2 ** reconnects)));
+    if (document.hidden && reconnects > 5) return; // stop if tab hidden and too many
+    setTimeout(connect, delay);
+  };
+  es.addEventListener('overlay', (ev) => {
+    const data = JSON.parse(ev.data);
+    CorrelationBar?.pushEvent({ type: 'overlay', ...pickMeta(data), ts: Date.now() });
+    window.dispatchEvent(new CustomEvent('overlay', { detail: data }));
+  });
+  es.addEventListener('trade', (ev) => {
+    const data = JSON.parse(ev.data);
+    CorrelationBar?.pushEvent({ type: 'trade', ...pickMeta(data), ts: Date.now() });
+    window.dispatchEvent(new CustomEvent('trade', { detail: data }));
+  });
+  es.addEventListener('ping', (ev) => {
+    const data = JSON.parse(ev.data);
+    CorrelationBar?.pushEvent({ type: 'ping', ...pickMeta(data), ts: Date.now() });
+  });
+}
+
+connect();

--- a/deploy/prometheus/alerts.yml
+++ b/deploy/prometheus/alerts.yml
@@ -50,3 +50,18 @@ groups:
     labels: { severity: ticket }
     annotations:
       summary: "Nėra equity points sugeneruotų paskutines 30m"
+
+- name: rum.rules
+  rules:
+  - alert: RUM_FCP_Degraded
+    expr: histogram_quantile(0.9, sum(rate(rum_fcp_seconds_bucket[15m])) by (le)) > 2
+    for: 30m
+    labels: { severity: ticket }
+    annotations:
+      summary: "RUM FCP p90 > 2s (30m)"
+  - alert: RUM_SSE_Unstable
+    expr: increase(rum_sse_reconnect_attempts_total[30m]) > 50
+    for: 30m
+    labels: { severity: ticket }
+    annotations:
+      summary: "SSE reconnect bandymai > 50 per 30m"

--- a/docs/observability-fe.md
+++ b/docs/observability-fe.md
@@ -1,0 +1,22 @@
+# Front-end Observability
+
+## Debug mode
+- Append `?debug=1` to the URL or run with `NODE_ENV=development` to force-enable widgets.
+
+## Correlation Bar
+- Call `CorrelationBar.init({ enabled: true, env: NODE_ENV });`.
+- Shows last 5 events (`overlay`, `trade`, `ping`, `http`).
+- Click the `req`/`trace` labels to copy identifiers for logs or trace search.
+
+## Network Inspector
+- Active only in development or with `?debug=1`.
+- Toggle with `Ctrl+~` to view the last HTTP requests and copy generated cURL.
+
+## Incident codes
+- User-visible errors display a toast with an incident code (request id).
+- "Copy incident code" copies the code to clipboard.
+- Use the code (`reqId`) to search server logs and traces.
+- Server logs include `reqId` and `traceId` fields which can be searched in Grafana or the log store to inspect the correlated trace.
+
+## Privacy
+- RUM metrics avoid any PII or user identifiers and do not include URL parameters.

--- a/src/app.js
+++ b/src/app.js
@@ -5,11 +5,13 @@ import { errorHandler } from './middleware/error-handler.js';
 import { metricsRouter, httpDuration, httpRequests } from './observability/metrics.js';
 import { sseRoutes } from './routes/sse.js';
 import { healthRoutes } from './routes/health.js';
+import { rumRouter } from './routes/rum.js';
 
 const app = express();
 
 app.use(requestId);
 app.use(loggerContext);
+app.use(express.json());
 app.use((req, res, next) => {
   const end = httpDuration.startTimer({ method: req.method, route: req.route?.path || req.path });
   res.on('finish', () => {
@@ -22,6 +24,7 @@ app.use((req, res, next) => {
 sseRoutes(app);
 healthRoutes(app);
 metricsRouter(app);
+app.use('/rum', rumRouter);
 
 app.get('/api/ping', (req, res) => {
   res.json({ reqId: req.reqId, pong: true });

--- a/src/metrics-rum.js
+++ b/src/metrics-rum.js
@@ -1,0 +1,10 @@
+import client from 'prom-client';
+
+export const rumFcp = new client.Histogram({ name: 'rum_fcp_seconds', help: 'FCP', buckets: [0.5, 1, 2, 3, 5, 8] });
+export const rumLcp = new client.Histogram({ name: 'rum_lcp_seconds', help: 'LCP', buckets: [1, 2, 3, 5, 8, 13] });
+export const rumTTFB = new client.Histogram({ name: 'rum_navigation_ttfb_seconds', help: 'TTFB', buckets: [0.1, 0.3, 0.6, 1, 2, 3] });
+export const rumLongtasks = new client.Counter({ name: 'rum_longtasks_total', help: 'Long tasks total' });
+export const rumLongtaskMax = new client.Gauge({ name: 'rum_longtask_max_ms', help: 'Max long task ms' });
+
+export const rumSseReconnects = new client.Counter({ name: 'rum_sse_reconnect_attempts_total', help: 'SSE reconnect attempts', labelNames: ['clientType'] });
+export const rumSseConnected = new client.Counter({ name: 'rum_sse_connected_seconds_total', help: 'SSE connected seconds', labelNames: ['clientType'] });

--- a/src/routes/rum.js
+++ b/src/routes/rum.js
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import { rumFcp, rumLcp, rumTTFB, rumLongtasks, rumLongtaskMax, rumSseReconnects, rumSseConnected } from '../metrics-rum.js';
+
+export const rumRouter = Router();
+
+rumRouter.post('/metrics', (req, res) => {
+  const b = req.body || {};
+  switch (b.type) {
+    case 'navigation':
+      if (b.ttfb != null) rumTTFB.observe(b.ttfb);
+      break;
+    case 'paint':
+      if (b.fcp != null) rumFcp.observe(b.fcp);
+      if (b.lcp != null) rumLcp.observe(b.lcp);
+      break;
+    case 'longtask':
+      if (b.longtasks) rumLongtasks.inc(b.longtasks);
+      if (b.longtaskMaxMs != null) rumLongtaskMax.set(b.longtaskMaxMs);
+      break;
+  }
+  res.json({ ok: true });
+});
+
+rumRouter.post('/sse', (req, res) => {
+  const { connectedSeconds = 0, reconnectAttempts = 0, clientType = 'web' } = req.body || {};
+  if (reconnectAttempts) rumSseReconnects.inc({ clientType }, reconnectAttempts);
+  if (connectedSeconds) rumSseConnected.inc({ clientType }, connectedSeconds);
+  res.json({ ok: true });
+});


### PR DESCRIPTION
## Summary
- add CorrelationBar widget and error toasts for user-level correlation
- send request ids via http wrapper and SSE client with reconnect telemetry
- expose RUM metrics and alerts for FCP and SSE reconnects

## Testing
- `npm test`
- `npm run lint` *(fails: "no-undef" etc)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1fa97eec83259fee881a68689955