### PR TITLE
UI v1.2.1 — Prefetch guards, Idle/Viewport Prefetch, Canonical JSON-LD base, Reduced-Motion, Theming, Sticky Breadcrumbs, Tabs Home/End

### DIFF
--- a/client/public/assets/ui-breadcrumbs.css
+++ b/client/public/assets/ui-breadcrumbs.css
@@ -4,3 +4,25 @@
 .breadcrumbs__sep{opacity:.5}
 .breadcrumbs__current{color:#e6e6e6}
 @media (max-width:768px){.breadcrumbs{top:56px;flex-wrap:wrap}}
+
+/* === UI v1.2.1 sticky breadcrumbs + truncation === */
+.ui-breadcrumbs {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(6px);
+}
+.ui-breadcrumbs .ui-breadcrumbs-list {
+  display: flex;
+  align-items: center;
+  gap: .4rem;
+  overflow: auto;
+  white-space: nowrap;
+  padding: .25rem 0;
+}
+.ui-breadcrumbs a,
+.ui-breadcrumbs li[aria-current] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 24ch;
+}

--- a/client/public/assets/ui-breadcrumbs.js
+++ b/client/public/assets/ui-breadcrumbs.js
@@ -65,9 +65,13 @@
     const old = navEl.querySelector(`#${JSONLD_ID}`);
     if (old) old.remove();
 
+    // === UI v1.2.1 canonical base ===
+    const canonicalHref = document.querySelector('link[rel="canonical"]')?.href;
     const baseAttr = navEl.getAttribute('data-bc-base');
     if (baseAttr === 'disable') return;
-    const base = baseAttr || location.origin;
+    const base = (baseAttr && baseAttr !== 'disable')
+      ? baseAttr
+      : (canonicalHref || document.baseURI || location.origin);
     const list = navEl.querySelector(SEL_LIST);
     if (!list) return;
 

--- a/client/public/assets/ui-loader.css
+++ b/client/public/assets/ui-loader.css
@@ -9,7 +9,7 @@
   position: relative;
   overflow: hidden;
   border-radius: 0.5rem;
-  background: linear-gradient(90deg, rgba(0,0,0,0.08), rgba(0,0,0,0.12), rgba(0,0,0,0.08));
+  background: linear-gradient(90deg, var(--sk1), var(--sk2), var(--sk1));
   background-size: 200% 100%;
   animation: ui-shimmer 1.2s infinite linear;
   min-height: 0.8rem;
@@ -34,3 +34,24 @@
 .ui-skeleton-table { display: grid; gap: 0.6rem; }
 .ui-skeleton-tr { display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 0.6rem; }
 .ui-skeleton-td { height: 0.9rem; }
+
+/* === UI v1.2.1 theming === */
+:root {
+  --sk1: rgba(0,0,0,.08);
+  --sk2: rgba(0,0,0,.12);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --sk1: rgba(255,255,255,.08);
+    --sk2: rgba(255,255,255,.14);
+  }
+}
+.ui-skeleton {
+  background: linear-gradient(90deg, var(--sk1), var(--sk2), var(--sk1));
+  background-size: 200% 100%;
+}
+
+/* Reduced motion (A11y) */
+@media (prefers-reduced-motion: reduce) {
+  .ui-skeleton { animation: none; }
+}


### PR DESCRIPTION
## Summary
- guard tab prefetch for hover-capable, non–save-data users and add idle/viewport prefetch, Home/End support, and optional scroll memory helpers
- derive breadcrumb JSON-LD base from canonical link with disable flag support
- theme skeleton loaders with reduced-motion handling and make breadcrumbs sticky with truncation

## Testing
- `npm test`
- `npm run lint` *(fails: window is not defined, navigator is not defined, requestIdleCallback is not defined, and more)*

------
https://chatgpt.com/codex/tasks/task_e_68ae28529ae48325bc5471e4e6b06176