### PR TITLE
feat: add overlay set management

### DIFF
--- a/migrations/2025-08-overlay-sets.sql
+++ b/migrations/2025-08-overlay-sets.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS overlay_sets (
+  id           BIGSERIAL PRIMARY KEY,
+  name         TEXT NOT NULL,
+  description  TEXT,
+  payload      JSONB NOT NULL,
+  pinned       BOOLEAN NOT NULL DEFAULT FALSE,
+  token        TEXT UNIQUE,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_overlay_sets_updated ON overlay_sets(updated_at DESC);
+
+CREATE OR REPLACE FUNCTION trg_overlay_sets_mts() RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS overlay_sets_set_updated ON overlay_sets;
+CREATE TRIGGER overlay_sets_set_updated BEFORE UPDATE ON overlay_sets
+FOR EACH ROW EXECUTE FUNCTION trg_overlay_sets_mts();

--- a/src/routes/analytics.overlay.sets.js
+++ b/src/routes/analytics.overlay.sets.js
@@ -1,0 +1,83 @@
+import express from 'express';
+import crypto from 'crypto';
+import { db } from '../storage/db.js';
+
+const router = express.Router();
+
+function sanitizePayload(p = {}) {
+  const version = 1;
+  const jobIds = Array.isArray(p.jobIds) ? p.jobIds.filter(n => Number.isFinite(Number(n))).slice(0, 12) : [];
+  const baseline = (p.baseline === 'live') ? 'live' : 'none';
+  const align = (p.align === 'first-common') ? 'first-common' : 'none';
+  const rebase = (p.rebase == null || p.rebase === '') ? null : Number(p.rebase);
+  const inline = p.inline && p.inline.optimizeJobId ? {
+    optimizeJobId: Number(p.inline.optimizeJobId),
+    n: Math.max(1, Math.min(10, Number(p.inline.n) || 3)),
+    tol: Math.max(0, Number(p.inline.tol) || 0)
+  } : null;
+  return { version, jobIds, baseline, align, rebase, ...(inline ? { inline } : {}) };
+}
+
+router.get('/analytics/overlay-sets', async (_req, res) => {
+  const { rows } = await db.query(`SELECT id, name, description, payload, pinned, token, created_at, updated_at
+                                   FROM overlay_sets ORDER BY pinned DESC, updated_at DESC LIMIT 100`);
+  res.json({ sets: rows });
+});
+
+router.get('/analytics/overlay-sets/:id', async (req, res) => {
+  const { rows } = await db.query(`SELECT id, name, description, payload, pinned, token, created_at, updated_at
+                                   FROM overlay_sets WHERE id=$1`, [req.params.id]);
+  if (!rows.length) return res.status(404).json({ error: 'not found' });
+  res.json(rows[0]);
+});
+
+router.post('/analytics/overlay-sets', async (req, res) => {
+  const { name, description, payload } = req.body || {};
+  if (!name) return res.status(400).json({ error: 'name required' });
+  const pl = sanitizePayload(payload);
+  const { rows } = await db.query(
+    `INSERT INTO overlay_sets(name, description, payload) VALUES($1,$2,$3) RETURNING *`,
+    [name, description || null, pl]
+  );
+  res.status(201).json(rows[0]);
+});
+
+router.put('/analytics/overlay-sets/:id', async (req, res) => {
+  const fields = [];
+  const args = [];
+  let i = 1;
+  if (req.body?.name != null) { fields.push(`name=$${i++}`); args.push(req.body.name); }
+  if (req.body?.description !== undefined) { fields.push(`description=$${i++}`); args.push(req.body.description); }
+  if (req.body?.payload) { fields.push(`payload=$${i++}`); args.push(sanitizePayload(req.body.payload)); }
+  if (req.body?.pinned != null) { fields.push(`pinned=$${i++}`); args.push(!!req.body.pinned); }
+  if (!fields.length) return res.status(400).json({ error: 'nothing to update' });
+  args.push(req.params.id);
+  const { rows } = await db.query(`UPDATE overlay_sets SET ${fields.join(', ')} WHERE id=$${i} RETURNING *`, args);
+  if (!rows.length) return res.status(404).json({ error: 'not found' });
+  res.json(rows[0]);
+});
+
+router.delete('/analytics/overlay-sets/:id', async (req, res) => {
+  const { rowCount } = await db.query(`DELETE FROM overlay_sets WHERE id=$1`, [req.params.id]);
+  if (!rowCount) return res.status(404).json({ error: 'not found' });
+  res.json({ ok: true });
+});
+
+router.post('/analytics/overlay-sets/:id/share', async (req, res) => {
+  const { rows } = await db.query(`SELECT id, payload, token FROM overlay_sets WHERE id=$1`, [req.params.id]);
+  if (!rows.length) return res.status(404).json({ error: 'not found' });
+  let token = rows[0].token;
+  if (!token) {
+    token = crypto.randomBytes(6).toString('base64url');
+    await db.query(`UPDATE overlay_sets SET token=$1 WHERE id=$2`, [token, req.params.id]);
+  }
+  res.json({ token, url: `/analytics.html?share=${token}` });
+});
+
+router.get('/analytics/overlay-sets/share/:token', async (req, res) => {
+  const { rows } = await db.query(`SELECT payload FROM overlay_sets WHERE token=$1`, [req.params.token]);
+  if (!rows.length) return res.status(404).json({ error: 'not found' });
+  res.json(rows[0].payload);
+});
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -34,6 +34,7 @@ import analyticsOverlayShareRoutes from './routes/analytics.overlay.share.js';
 import analyticsOptimizeTopRoutes from './routes/analytics.optimize.top.js';
 import analyticsOptimizeInlineRoutes from './routes/analytics.optimize.inline.js';
 import analyticsOverlayRoutes from './routes/analytics-overlay.js';
+import analyticsOverlaySetsRoutes from './routes/analytics.overlay.sets.js';
 import { listArtifacts, readArtifactCSV, normalizeEquity } from './services/analyticsArtifacts.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -77,6 +78,7 @@ app.use('/', analyticsJobsRoutes);
   app.use('/', analyticsOptimizeTopRoutes);
   app.use('/', analyticsOptimizeInlineRoutes);
   app.use('/', analyticsOverlayRoutes);
+  app.use('/', analyticsOverlaySetsRoutes);
   sseRoutes(app);
   metricsRouter(app);
 


### PR DESCRIPTION
## Summary
- add migration and routes to save, load, and share overlay sets
- expose overlay set APIs in server
- extend analytics overlays UI with save/load/share overlay set panel

## Testing
- `npm test`
- `npm run lint` (fails: 'window' is not defined and other repo-wide lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68ae299ed034832581aec9d2b09559b3