### PR TITLE
feat: add analytics HTML report

### DIFF
--- a/client/public/assets/modules/analytics/overlays.js
+++ b/client/public/assets/modules/analytics/overlays.js
@@ -19,6 +19,7 @@ export async function mount(root){
     <div style="display:flex;gap:8px;margin-top:8px">
       <button id="ov-report-zip" class="btn">Download Report (ZIP)</button>
       <button id="ov-report-zip-png" class="btn">Download Report + PNG</button>
+      <button id="ov-report-html" class="btn">Open HTML Report</button>
     </div>
     <div style="margin-top:12px;display:flex;gap:8px;align-items:end;flex-wrap:wrap">
       <div><label>Optimize job ID<br><input id="ov-top-id" style="width:100px"></label></div>
@@ -41,7 +42,7 @@ export async function mount(root){
 
   const el = id => root.querySelector(id);
   const input = { type: el('#ov-type'), symbol: el('#ov-symbol'), strategy: el('#ov-strategy'), topId: el('#ov-top-id'), topN: el('#ov-top-n'), tol: el('#ov-tol') };
-  const btn = { load: el('#ov-load'), apply: el('#ov-apply'), clear: el('#ov-clear'), export: el('#ov-export'), share: el('#ov-share'), reportZip: el('#ov-report-zip'), reportZipPng: el('#ov-report-zip-png'), topLoad: el('#ov-top-load'), topInline: el('#ov-top-inline') };
+  const btn = { load: el('#ov-load'), apply: el('#ov-apply'), clear: el('#ov-clear'), export: el('#ov-export'), share: el('#ov-share'), reportZip: el('#ov-report-zip'), reportZipPng: el('#ov-report-zip-png'), reportHtml: el('#ov-report-html'), topLoad: el('#ov-top-load'), topInline: el('#ov-top-inline') };
   const box = { jobs: el('#ov-jobs'), stats: el('#ov-stats'), top: el('#ov-top-results'), sets: el('#ov-set-list') };
   const chkBaseline = el('#ov-baseline');
   const selectAlign = el('#ov-align');
@@ -416,6 +417,20 @@ export async function mount(root){
     } catch(e){
       Toast.open({ title:'Report failed', description: e.message, variant:'error' });
     }
+  });
+  btn.reportHtml.addEventListener('click', ()=>{
+    const s = currentSelection();
+    if (!s.jobIds.length){ Toast.open({ title:'Pick at least one job', variant:'warning' }); return; }
+    const params = new URLSearchParams({
+      job_ids: s.jobIds.join(','),
+      baseline: s.baseline,
+      overlay_align: s.align,
+      overlay_rebase: s.rebase||'',
+      ds: 'lttb',
+      n: '1500'
+    });
+    const url = shareToken ? `/analytics/overlays/share/${shareToken}/report.html` : `/analytics/overlays/report.html?${params.toString()}`;
+    window.open(url, '_blank');
   });
   btn.topLoad.addEventListener('click', loadTopN);
   btn.topInline.addEventListener('click', loadTopNInline);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "cors": "^2.8.5",
         "csv-parse": "^5.6.0",
         "dotenv": "^16.4.5",
+        "escape-html": "^1.0.3",
         "express": "^4.19.2",
         "node-telegram-bot-api": "^0.66.0",
         "pg": "^8.16.3",
@@ -2894,7 +2895,8 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cors": "^2.8.5",
     "csv-parse": "^5.6.0",
     "dotenv": "^16.4.5",
+    "escape-html": "^1.0.3",
     "express": "^4.19.2",
     "node-telegram-bot-api": "^0.66.0",
     "pg": "^8.16.3",

--- a/src/routes/analytics.report.html.js
+++ b/src/routes/analytics.report.html.js
@@ -1,0 +1,53 @@
+import express from 'express';
+import { listArtifacts, readArtifactCSV, normalizeEquity } from '../services/analyticsArtifacts.js';
+import { htmlPage } from '../services/reportHtml.js';
+import { eTagOfJSON, applyCacheHeaders, handleConditionalReq } from '../services/httpCache.js';
+
+async function loadSeries(jobIds){
+  const out = [];
+  for (const id of jobIds){
+    const arts = await listArtifacts(id);
+    const a = arts.find(x => /equity\.csv$|oos_equity\.csv$/i.test(x.path));
+    if (!a) continue;
+    const rows = await readArtifactCSV(id, a.path);
+    const eq = normalizeEquity(rows);
+    if (eq.length) out.push({ jobId: id, label: '#'+id, equity: eq });
+  }
+  return out;
+}
+
+const router = express.Router();
+
+router.get('/analytics/overlays/report.html', async (req, res) => {
+  const ids = String(req.query.job_ids||'').split(',').map(s=>Number(s.trim())).filter(Boolean).slice(0,12);
+  if (!ids.length) return res.status(400).send('job_ids required');
+  const params = {
+    baseline: req.query.baseline==='live' ? 'live' : 'none',
+    align: req.query.overlay_align==='first-common' ? 'first-common' : 'none',
+    rebase: (req.query.overlay_rebase==='' || req.query.overlay_rebase==null) ? null : Number(req.query.overlay_rebase),
+    ds: req.query.ds || 'none',
+    n: req.query.n ? Number(req.query.n) : undefined
+  };
+
+  const items = await loadSeries(ids);
+  const baseline = null;
+  const payload = { jobIds: ids, items, baseline, params };
+  const etag = eTagOfJSON({ ids, count: items.length, p: params });
+  const now = Date.now();
+  if (handleConditionalReq(req, res, etag, now)) {
+    applyCacheHeaders(res, { etag, lastModified: now, maxAge: 300 });
+    return res.status(304).end();
+  }
+
+  const html = htmlPage({
+    title: `Analytics Report – ${ids.map(id=>'#'+id).join(', ')}`,
+    dataJson: JSON.stringify(payload),
+    generatedAt: now,
+    params
+  });
+  applyCacheHeaders(res, { etag, lastModified: now, maxAge: 300 });
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  res.send(html);
+});
+
+export default router;

--- a/src/routes/analytics.report.share.html.js
+++ b/src/routes/analytics.report.share.html.js
@@ -1,0 +1,57 @@
+import express from 'express';
+import { db } from '../storage/db.js';
+import { htmlPage } from '../services/reportHtml.js';
+import { listArtifacts, readArtifactCSV, normalizeEquity } from '../services/analyticsArtifacts.js';
+import { eTagOfJSON, applyCacheHeaders, handleConditionalReq } from '../services/httpCache.js';
+
+async function loadSeries(jobIds){
+  const out = [];
+  for (const id of jobIds){
+    const arts = await listArtifacts(id);
+    const a = arts.find(x => /equity\.csv$|oos_equity\.csv$/i.test(x.path));
+    if (!a) continue;
+    const rows = await readArtifactCSV(id, a.path);
+    const eq = normalizeEquity(rows);
+    if (eq.length) out.push({ jobId: id, label: '#'+id, equity: eq });
+  }
+  return out;
+}
+
+const router = express.Router();
+
+router.get('/analytics/overlays/share/:token/report.html', async (req,res)=>{
+  let payload = null;
+  const { rows } = await db.query(`SELECT payload FROM overlay_shares WHERE token=$1`, [req.params.token]);
+  if (rows.length) payload = rows[0].payload || {};
+  if (!payload){
+    const r2 = await db.query(`SELECT payload FROM overlay_sets WHERE token=$1`, [req.params.token]);
+    if (r2.rows.length) payload = r2.rows[0].payload || {};
+  }
+  if (!payload) return res.status(404).send('share token not found');
+  const ids = (payload.jobIds||[]).slice(0,12);
+  const params = {
+    baseline: payload.baseline || 'none',
+    align: payload.align || 'none',
+    rebase: payload.rebase ?? null,
+    ds: 'none', n: undefined
+  };
+  const items = await loadSeries(ids);
+  const body = { jobIds: ids, items, baseline: null, params };
+  const etag = eTagOfJSON({ token: req.params.token, count: items.length, p: params });
+  const now = Date.now();
+  if (handleConditionalReq(req, res, etag, now)) {
+    applyCacheHeaders(res, { etag, lastModified: now, maxAge: 600 });
+    return res.status(304).end();
+  }
+  const html = htmlPage({
+    title: `Analytics Report – share:${req.params.token}`,
+    dataJson: JSON.stringify(body),
+    generatedAt: now,
+    params
+  });
+  applyCacheHeaders(res, { etag, lastModified: now, maxAge: 600 });
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  res.send(html);
+});
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -36,6 +36,8 @@ import analyticsOptimizeInlineRoutes from './routes/analytics.optimize.inline.js
 import analyticsOverlayRoutes from './routes/analytics-overlay.js';
 import analyticsOverlaySetsRoutes from './routes/analytics.overlay.sets.js';
 import analyticsReportRoutes from './routes/analytics.report.js';
+import analyticsReportHtmlRoutes from './routes/analytics.report.html.js';
+import analyticsReportShareHtmlRoutes from './routes/analytics.report.share.html.js';
 import { listArtifacts, readArtifactCSV, normalizeEquity } from './services/analyticsArtifacts.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -81,6 +83,8 @@ app.use('/', analyticsJobsRoutes);
   app.use('/', analyticsOverlayRoutes);
   app.use('/', analyticsOverlaySetsRoutes);
   app.use('/', analyticsReportRoutes);
+  app.use('/', analyticsReportHtmlRoutes);
+  app.use('/', analyticsReportShareHtmlRoutes);
   sseRoutes(app);
   metricsRouter(app);
 

--- a/src/services/httpCache.js
+++ b/src/services/httpCache.js
@@ -1,0 +1,27 @@
+import crypto from 'crypto';
+
+export function eTagOfJSON(obj) {
+  const json = JSON.stringify(obj);
+  const hash = crypto.createHash('sha1').update(json).digest('hex');
+  return '"' + hash + '"';
+}
+
+export function applyCacheHeaders(res, { etag, lastModified, maxAge }) {
+  if (etag) res.setHeader('ETag', etag);
+  if (lastModified) res.setHeader('Last-Modified', new Date(lastModified).toUTCString());
+  if (maxAge != null) {
+    res.setHeader('Cache-Control', `public, max-age=${maxAge}`);
+  }
+}
+
+export function handleConditionalReq(req, _res, etag, lastModified) {
+  const inm = req.headers['if-none-match'];
+  if (inm && etag && inm === etag) return true;
+  const ims = req.headers['if-modified-since'];
+  if (ims) {
+    const since = Date.parse(ims);
+    if (!Number.isNaN(since) && lastModified && since >= lastModified) return true;
+  }
+  return false;
+}
+

--- a/src/services/reportHtml.js
+++ b/src/services/reportHtml.js
@@ -1,0 +1,174 @@
+import escapeHtml from 'escape-html';
+
+export function htmlPage({ title, dataJson, generatedAt, params }) {
+  const now = new Date(generatedAt || Date.now()).toISOString();
+  const t = escapeHtml(title || 'Analytics Report');
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${t}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark light">
+<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+<link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+<style>
+  :root{--bg:#0f141c;--fg:#e6edf3;--muted:#9aa0a6;--card:#141b24;--accent:#4cc9f0}
+  html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);font:14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Arial}
+  .wrap{max-width:1100px;margin:0 auto;padding:20px}
+  h1{font-size:20px;margin:0 0 12px}
+  .row{display:flex;gap:12px;flex-wrap:wrap;align-items:flex-start}
+  .card{background:var(--card);border:1px solid #1d2532;border-radius:12px;padding:12px}
+  .btn{background:#1c2430;border:1px solid #243042;border-radius:8px;color:#fff;padding:8px 10px;cursor:pointer}
+  .muted{color:var(--muted)}
+  table{width:100%;border-collapse:collapse}
+  th,td{padding:8px;border-bottom:1px solid #1d2532;text-align:right}
+  th:first-child,td:first-child{text-align:left}
+  canvas{max-width:100%}
+  .pill{display:inline-block;border:1px solid #2a3547;border-radius:999px;padding:2px 8px;font-size:12px;margin-right:6px}
+  @media print{
+    .noprint{display:none!important}
+    .card{break-inside:avoid}
+    body{background:#fff;color:#000}
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="row">
+    <div class="card" style="flex:1 1 auto">
+      <h1>Analytics Report</h1>
+      <div class="muted">Generated: ${now}</div>
+      <div class="muted">Params: baseline=<b>${escapeHtml(params.baseline||'none')}</b>, align=<b>${escapeHtml(params.align||'none')}</b>, rebase=<b>${params.rebase??'-'}</b>, ds=<b>${escapeHtml(params.ds||'none')}</b> n=<b>${params.n||''}</b></div>
+    </div>
+    <div class="card noprint" style="display:flex;gap:8px;align-items:center">
+      <button id="btn-zip" class="btn">Download ZIP</button>
+      <button id="btn-copy" class="btn">Copy Link</button>
+      <button onclick="window.print()" class="btn">Print / PDF</button>
+    </div>
+  </header>
+
+  <section class="card">
+    <canvas id="chart" height="360"></canvas>
+  </section>
+
+  <section class="card">
+    <h2 style="margin:0 0 8px;font-size:16px">Stats</h2>
+    <table id="stats"><thead>
+      <tr><th>Series</th><th>From</th><th>To</th><th>Points</th><th>Return</th><th>MaxDD</th><th>ΔReturn vs Baseline</th><th>ΔMaxDD</th></tr>
+    </thead><tbody></tbody></table>
+  </section>
+
+  <section class="card">
+    <h2 style="margin:0 0 8px;font-size:16px">Notes</h2>
+    <ul class="muted" style="margin:0 0 0 18px">
+      <li>Chart is rendered client-side with Chart.js using the embedded JSON below.</li>
+      <li>Use the Print/PDF button for a portable copy; or Download ZIP for CSV + JSON bundle.</li>
+    </ul>
+  </section>
+</div>
+
+<script id="report-data" type="application/json">${dataJson}</script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="" crossorigin="anonymous"></script>
+<script>
+(function(){
+  const el = document.getElementById('report-data');
+  const data = JSON.parse(el.textContent || '{}');
+  const ctx = document.getElementById('chart').getContext('2d');
+
+  // Align + Rebase kaip Overlays v2
+  function alignAndRebase(series, baseline, settings){
+    const { align, rebase } = settings || {};
+    const all = [...series, ...(baseline? [baseline] : [])];
+    if (align === 'first-common') {
+      const sets = all.map(s=> new Set(s.equity.map(p=>p.ts)));
+      let firstCommon = null;
+      const cand = [...sets[0]].sort((a,b)=>a-b);
+      for (const t of cand) if (sets.every(S => S.has(t))) { firstCommon = t; break; }
+      if (firstCommon!=null) all.forEach(s => { s.equity = s.equity.filter(p=> p.ts >= firstCommon); });
+    }
+    if (rebase) {
+      all.forEach(s=>{
+        if (!s.equity.length) return;
+        const y0 = s.equity[0].equity;
+        if (!y0) return;
+        s.equity = s.equity.map(p=> ({ ts:p.ts, equity: (rebase * (p.equity / y0)) }));
+      });
+    }
+    return { series, baseline };
+  }
+
+  function pct(v){ return v==null? '-' : (v*100).toFixed(2)+'%'; }
+  function pp(v){ return v==null? '-' : (v*100).toFixed(2)+'pp'; }
+  function statsOf(s){
+    if (!s.equity?.length) return {ret:null,dd:null,from:null,to:null,n:0};
+    const from = s.equity[0].ts, to = s.equity.at(-1).ts, n = s.equity.length;
+    const ret = s.equity.at(-1).equity / s.equity[0].equity - 1;
+    let peak=-Infinity, dd=0; s.equity.forEach(p=>{ peak=Math.max(peak,p.equity); dd=Math.min(dd,p.equity/peak-1); });
+    return {ret,dd,from,to,n};
+  }
+
+  const settings = { align: data.params.align, rebase: data.params.rebase };
+  const base = data.baseline || null;
+  const series = data.items || [];
+  const { series:aligned, baseline:alignedBase } = alignAndRebase(series.map(x=>({ ...x, equity:[...x.equity] })), base? { ...base, equity:[...base.equity] } : null, settings);
+
+  // Chart
+  const colors = ['#4cc9f0','#ffd166','#06d6a0','#ef476f','#118ab2','#f72585','#9b5de5','#5bc0eb','#c2f970','#ff9f1c'];
+  function color(i){ return colors[i % colors.length]; }
+  const datasets = [];
+  if (alignedBase) datasets.push({
+    label: 'Baseline (Live)',
+    data: alignedBase.equity.map(p=>({x:p.ts,y:p.equity})),
+    borderWidth:2, pointRadius:0
+  });
+  aligned.forEach((s,i)=>{
+    datasets.push({
+      label: s.label || (s.jobId? ('#'+s.jobId):'overlay'),
+      data: s.equity.map(p=>({x:p.ts,y:p.equity})),
+      borderDash:[6,4], borderWidth:2, pointRadius:0, borderColor: color(i + (alignedBase?1:0))
+    });
+  });
+  const chart = new Chart(ctx, {
+    type: 'line',
+    data: { datasets },
+    options: { parsing:false, animation:false, plugins:{ legend:{ position:'bottom' } }, scales:{ x:{ type:'timeseries' }, y:{ beginAtZero:false } } }
+  });
+
+  // Stats table
+  const tbody = document.querySelector('#stats tbody');
+  const b = alignedBase? statsOf(alignedBase) : null;
+  function row(name, s){
+    const st = statsOf(s);
+    const dR = (b && st.ret!=null && b.ret!=null) ? (st.ret - b.ret) : null;
+    const dD = (b && st.dd!=null && b.dd!=null) ? (st.dd - b.dd) : null;
+    const fmtDate = ts => ts? (new Date(ts)).toISOString().slice(0,19).replace('T',' ') : '-';
+    return '<tr><td>'+name+'</td><td>'+fmtDate(st.from)+'</td><td>'+fmtDate(st.to)+'</td><td>'+st.n+'</td><td>'+pct(st.ret)+'</td><td>'+pct(st.dd)+'</td><td>'+pp(dR)+'</td><td>'+pp(dD)+'</td></tr>';
+  }
+  const rows = [];
+  if (alignedBase) rows.push(row('Baseline (Live)', alignedBase));
+  aligned.forEach((s)=> rows.push(row(s.label || (s.jobId? ('#'+s.jobId):'overlay'), s)));
+  tbody.innerHTML = rows.join('');
+
+  // Buttons
+  const qs = new URLSearchParams({
+    job_ids: (data.jobIds || []).join(','),
+    baseline: data.params.baseline || 'none',
+    overlay_align: data.params.align || 'none',
+    overlay_rebase: data.params.rebase ?? '',
+    ds: data.params.ds || '',
+    n: data.params.n || ''
+  }).toString();
+  const zipUrl = '/analytics/overlays/report?' + qs;
+  document.getElementById('btn-zip').addEventListener('click', ()=> { window.open(zipUrl, '_blank', 'noopener'); });
+
+  document.getElementById('btn-copy').addEventListener('click', async ()=>{
+    try { await navigator.clipboard.writeText(location.href); alert('Link copied'); } catch { alert('Copy failed'); }
+  });
+})();
+</script>
+</body></html>`;
+}
+
+export default { htmlPage };


### PR DESCRIPTION
## Summary
- add helper to generate printable HTML reports with Chart.js graphs and stats table
- expose `/analytics/overlays/report.html` and share-token `/analytics/overlays/share/:token/report.html` endpoints with caching
- wire up front-end button to open HTML report and register routes in server

## Testing
- `npm test`
- `npm run lint` *(fails: Empty block statement; 'overlayRebase' assigned but never used; Parsing error in reportHtml; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68af089793a88325b1a094b13e99d7ac