### PR TITLE
feat: unify timeIndicator signature and fix indicator wrappers

### DIFF
--- a/src/signal/indicators/ai.js
+++ b/src/signal/indicators/ai.js
@@ -1,7 +1,7 @@
+import { timeIndicator } from '../instrumentation.js';
+
 export async function aiScore(candles) { /* ... RETURN: { value: <0..1> } */ }
 
-import { timeIndicator } from '../instrumentation.js';
-export function aiScoreInstrumented(meta) {
-  const { candles } = meta;
-  return timeIndicator({ ...meta, indicator: 'ai_score' }, aiScore, candles);
+export function aiScoreInstrumented({ candles, symbol, interval, strategy }) {
+  return timeIndicator({ indicator: 'ai_score', symbol, interval, strategy }, aiScore, candles);
 }

--- a/src/signal/indicators/atr.js
+++ b/src/signal/indicators/atr.js
@@ -1,6 +1,7 @@
+import { timeIndicator } from '../instrumentation.js';
+
 export function computeATR14(candles) { /* ... */ }
 
-import { timeIndicator } from '../instrumentation.js';
 export function atr14Instrumented({ candles, symbol, interval, strategy }) {
   return timeIndicator({ indicator: 'atr14', symbol, interval, strategy }, computeATR14, candles);
 }

--- a/src/signal/indicators/patterns.js
+++ b/src/signal/indicators/patterns.js
@@ -1,7 +1,7 @@
+import { timeIndicator } from '../instrumentation.js';
+
 export function detectBullishEngulfing(candles) { /* ... RETURN: boolean */ }
 
-import { timeIndicator } from '../instrumentation.js';
-export function bullishEngulfingInstrumented(meta) {
-  const { candles } = meta;
-  return timeIndicator({ ...meta, indicator: 'bullish_engulfing' }, detectBullishEngulfing, candles);
+export function bullishEngulfingInstrumented({ candles, symbol, interval, strategy }) {
+  return timeIndicator({ indicator: 'bullish_engulfing', symbol, interval, strategy }, detectBullishEngulfing, candles);
 }

--- a/src/signal/indicators/rsi14.js
+++ b/src/signal/indicators/rsi14.js
@@ -1,10 +1,10 @@
+import { timeIndicator } from '../instrumentation.js';
+
 // Tavo originali funkcija (palik kaip yra)
 export function computeRSI14(candles) {
   // ... grąžina { value, series? }
 }
 
-// Instrumentuotas wrapper
-import { timeIndicator } from '../instrumentation.js';
 export function rsi14Instrumented({ candles, symbol, interval, strategy }) {
   return timeIndicator({ indicator: 'rsi14', symbol, interval, strategy }, computeRSI14, candles);
 }

--- a/src/signal/indicators/trend.js
+++ b/src/signal/indicators/trend.js
@@ -1,7 +1,7 @@
+import { timeIndicator } from '../instrumentation.js';
+
 export function computeTrend(candles) { /* ... RETURN: 'up'|'down'|'range' */ }
 
-import { timeIndicator } from '../instrumentation.js';
-export function trendInstrumented(meta) {
-  const { candles } = meta;
-  return timeIndicator({ ...meta, indicator: 'trend' }, computeTrend, candles);
+export function trendInstrumented({ candles, symbol, interval, strategy }) {
+  return timeIndicator({ indicator: 'trend', symbol, interval, strategy }, computeTrend, candles);
 }

--- a/src/signal/instrumentation.js
+++ b/src/signal/instrumentation.js
@@ -1,25 +1,56 @@
-import { indicatorLatency, dataNanInputs, dataMissingCandles, dataStaleSeconds, signalEmitted, signalSuppressed, riskRejections } from '../metrics-signal.js';
+import {
+  indicatorLatency,
+  dataNanInputs,
+  dataMissingCandles,
+  dataStaleSeconds,
+  signalEmitted,
+  signalSuppressed,
+  riskRejections,
+} from '../metrics-signal.js';
 
 // Returns true when indicator output is valid.
-// Gotchas: pattern detectors often return booleans and trend detectors return
-// strings like 'up'/'down', so those should not count as NaN.
+// Booleans and strings are valid; numbers must be finite; objects with
+// a `value` field are checked recursively for finiteness. Anything else that's
+// non-null is treated as valid so instrumentation doesn't reject unusual types.
 function isValidIndicatorValue(raw) {
   if (raw == null) return false; // null or undefined
-  const v = (raw && typeof raw === 'object' && 'value' in raw) ? raw.value : raw;
+  const v = raw && typeof raw === 'object' && 'value' in raw ? raw.value : raw;
   const t = typeof v;
   if (t === 'number') return Number.isFinite(v);
   if (t === 'boolean') return true;
   if (t === 'string') return true;
-  // For other objects/arrays we treat them as valid; instrumentation should not
-  // penalize unusual but non-null types.
   return true;
 }
 
-export async function timeIndicator({ fn, indicator, symbol, interval, strategy }, ...args) {
+// Accept either: (meta, fn, ...args) OR ({ fn, indicator, ... }, ...args)
+function resolveArgs(arg1, arg2) {
+  if (typeof arg1 === 'object' && typeof arg2 === 'function') {
+    return [arg1, arg2];
+  }
+  if (typeof arg1 === 'object' && arg1 && typeof arg1.fn === 'function') {
+    const { fn, ...meta } = arg1;
+    return [meta, fn];
+  }
+  return [null, null];
+}
+
+export async function timeIndicator(arg1, arg2, ...args) {
+  const [meta, fn] = resolveArgs(arg1, arg2);
+  if (typeof fn !== 'function') {
+    console.error('[timeIndicator] invalid fn', {
+      metaType: typeof arg1,
+      fnType: typeof arg2,
+      indicator: meta?.indicator,
+    });
+    return null;
+  }
+  const { indicator, symbol, interval, strategy } = meta;
   const end = indicatorLatency.startTimer({ indicator, symbol, interval, strategy });
   try {
     const out = await fn(...args);
-    if (!isValidIndicatorValue(out)) dataNanInputs.inc({ indicator, symbol, interval });
+    if (!isValidIndicatorValue(out)) {
+      dataNanInputs.inc({ indicator, symbol, interval });
+    }
     return out;
   } finally {
     end();


### PR DESCRIPTION
## Summary
- allow `timeIndicator` to accept both legacy `{fn,...}` and new `(meta, fn)` signatures with runtime guard
- standardize indicator wrappers to always pass compute function explicitly
- keep valid value checks and add error logging to avoid pipeline crashes

## Testing
- `npm test`
- `DATABASE_URL=postgres://localhost/test DEBUG_OBSERV=1 npm run dev` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68af12d3c5408325a8b677c6ef84e626