### PR TITLE
Analytics HTML Report v2: inline TOP-N + artifacts + live baseline

### DIFF
--- a/src/routes/analytics.report.html.js
+++ b/src/routes/analytics.report.html.js
@@ -1,4 +1,6 @@
 import express from 'express';
+import fs from 'fs';
+import path from 'path';
 import { listArtifacts, readArtifactCSV, normalizeEquity } from '../services/analyticsArtifacts.js';
 import { htmlPage } from '../services/reportHtml.js';
 import { eTagOfJSON, applyCacheHeaders, handleConditionalReq } from '../services/httpCache.js';
@@ -16,6 +18,28 @@ async function loadSeries(jobIds){
   return out;
 }
 
+async function loadArtifactsMap(jobIds){
+  const map = {};
+  for (const id of jobIds){
+    const arts = await listArtifacts(id);
+    map[id] = arts.map(a => ({
+      id: a.id,
+      kind: a.kind,
+      label: a.label || a.path,
+      size_bytes: a.size_bytes || 0,
+      download: `/jobs/${id}/artifacts/${a.id}/download`
+    }));
+  }
+  return map;
+}
+
+function parseInlineParams(q){
+  const optimizeId = Number(q.inline_optimize_id || 0) || null;
+  const n = Math.max(1, Math.min(10, Number(q.inline_n) || 0));
+  const tol = Math.max(0, Number(q.inline_tol) || 0);
+  return optimizeId ? { optimizeJobId: optimizeId, n, tol } : null;
+}
+
 const router = express.Router();
 
 router.get('/analytics/overlays/report.html', async (req, res) => {
@@ -28,11 +52,37 @@ router.get('/analytics/overlays/report.html', async (req, res) => {
     ds: req.query.ds || 'none',
     n: req.query.n ? Number(req.query.n) : undefined
   };
+  const inlineReq = parseInlineParams(req.query);
 
   const items = await loadSeries(ids);
-  const baseline = null;
-  const payload = { jobIds: ids, items, baseline, params };
-  const etag = eTagOfJSON({ ids, count: items.length, p: params });
+  const artifactsByJobId = await loadArtifactsMap(ids);
+
+  let inline = [];
+  if (inlineReq){
+    try {
+      const arts = await listArtifacts(inlineReq.optimizeJobId);
+      const j = arts.find(x => /optimize_topk_equity\.json$/i.test(x.path));
+      if (j){
+        const raw = JSON.parse(fs.readFileSync(path.resolve(j.path), 'utf8'));
+        inline = (raw || []).slice(0, inlineReq.n).map(it => ({
+          jobId: null,
+          label: it.label,
+          params: it.params || {},
+          equity: it.equity || []
+        }));
+      }
+      } catch (err) { /* ignore */ }
+  }
+
+  let baseline = null;
+  if (params.baseline === 'live'){
+      try {
+        baseline = null; // TODO: integrate live baseline helper
+      } catch (err) { /* ignore */ }
+  }
+
+  const payload = { jobIds: ids, items, inline, artifactsByJobId, baseline, params, inlineReq };
+  const etag = eTagOfJSON({ ids, count: items.length, inline: inline?.length||0, p: params });
   const now = Date.now();
   if (handleConditionalReq(req, res, etag, now)) {
     applyCacheHeaders(res, { etag, lastModified: now, maxAge: 300 });


### PR DESCRIPTION
## Summary
- support inline TOP-N overlays and artifacts in analytics report endpoints
- render inline series and artifacts table in HTML report with header pills
- prepare live baseline hook for future integration

## Testing
- `npm run lint` *(fails: 'window is not defined' and other no-undef errors in unrelated assets)*
- `npm test` *(fails: Cannot find module '/workspace/crypto-signals/test')*


------
https://chatgpt.com/codex/tasks/task_e_68af155387988325a1730bec41dcaf7e