### PR TITLE
Make indicator wrappers call real compute fns + type-aware NaN detection

### DIFF
--- a/src/routes/debug-observ.js
+++ b/src/routes/debug-observ.js
@@ -4,7 +4,7 @@ import { generateSignals } from '../signal/generateSignals.js';
 export const debugObservRouter = Router();
 
 debugObservRouter.post('/debug/run-indicators', async (req, res) => {
-  const { symbol = 'SOLUSDT', interval = '1m', n = 200 } = req.body || {};
+  const { symbol = 'SOLUSDT', interval = '1m', n = 200, force = false } = req.body || {};
   // sugeneruok paprastas 1m žvakes
   const now = Date.now();
   const candles = Array.from({ length: n }, (_, i) => {
@@ -15,6 +15,6 @@ debugObservRouter.post('/debug/run-indicators', async (req, res) => {
     const low = Math.min(open, close) - Math.random();
     return { ts, timestamp: ts, open, high, low, close };
   });
-  const signals = generateSignals(candles, { symbol, interval, strategy: 'dev-smoke' });
+  const signals = generateSignals(candles, { symbol, interval, strategy: 'dev-smoke', force });
   res.json({ ok: true, count: signals.length });
 });

--- a/src/signal/indicators/ai.core.js
+++ b/src/signal/indicators/ai.core.js
@@ -1,0 +1,9 @@
+import { rsi } from '../../indicators/rsi.js';
+
+export function aiScore(candles) {
+  const values = candles.map(c => c.close);
+  const r = rsi(values, 14);
+  if (r == null) return null;
+  return { value: Math.max(0, Math.min(1, r / 100)) };
+}
+

--- a/src/signal/indicators/ai.js
+++ b/src/signal/indicators/ai.js
@@ -1,6 +1,5 @@
 import { timeIndicator } from '../instrumentation.js';
-
-export async function aiScore(candles) { /* ... RETURN: { value: <0..1> } */ }
+import { aiScore } from './ai.core.js';
 
 export function aiScoreInstrumented({ candles, symbol, interval, strategy }) {
   return timeIndicator({ indicator: 'ai_score', symbol, interval, strategy }, aiScore, candles);

--- a/src/signal/indicators/atr.core.js
+++ b/src/signal/indicators/atr.core.js
@@ -1,0 +1,7 @@
+import { atr } from '../../indicators/atr.js';
+
+export function computeATR14(candles) {
+  const value = atr(candles, 14);
+  return value == null ? null : { value };
+}
+

--- a/src/signal/indicators/atr.js
+++ b/src/signal/indicators/atr.js
@@ -1,6 +1,5 @@
 import { timeIndicator } from '../instrumentation.js';
-
-export function computeATR14(candles) { /* ... */ }
+import { computeATR14 } from './atr.core.js';
 
 export function atr14Instrumented({ candles, symbol, interval, strategy }) {
   return timeIndicator({ indicator: 'atr14', symbol, interval, strategy }, computeATR14, candles);

--- a/src/signal/indicators/patterns.core.js
+++ b/src/signal/indicators/patterns.core.js
@@ -1,0 +1,8 @@
+import { bullishEngulfing } from '../../indicators/patterns.js';
+
+export function detectBullishEngulfing(candles) {
+  if (!Array.isArray(candles) || candles.length < 2) return false;
+  const [c1, c2] = candles.slice(-2);
+  return bullishEngulfing(c1, c2);
+}
+

--- a/src/signal/indicators/patterns.js
+++ b/src/signal/indicators/patterns.js
@@ -1,6 +1,5 @@
 import { timeIndicator } from '../instrumentation.js';
-
-export function detectBullishEngulfing(candles) { /* ... RETURN: boolean */ }
+import { detectBullishEngulfing } from './patterns.core.js';
 
 export function bullishEngulfingInstrumented({ candles, symbol, interval, strategy }) {
   return timeIndicator({ indicator: 'bullish_engulfing', symbol, interval, strategy }, detectBullishEngulfing, candles);

--- a/src/signal/indicators/rsi14.core.js
+++ b/src/signal/indicators/rsi14.core.js
@@ -1,0 +1,8 @@
+import { rsi } from '../../indicators/rsi.js';
+
+export function computeRSI14(candles) {
+  const values = candles.map(c => c.close);
+  const value = rsi(values, 14);
+  return value == null ? null : { value };
+}
+

--- a/src/signal/indicators/rsi14.js
+++ b/src/signal/indicators/rsi14.js
@@ -1,9 +1,5 @@
 import { timeIndicator } from '../instrumentation.js';
-
-// Tavo originali funkcija (palik kaip yra)
-export function computeRSI14(candles) {
-  // ... grąžina { value, series? }
-}
+import { computeRSI14 } from './rsi14.core.js';
 
 export function rsi14Instrumented({ candles, symbol, interval, strategy }) {
   return timeIndicator({ indicator: 'rsi14', symbol, interval, strategy }, computeRSI14, candles);

--- a/src/signal/indicators/trend.core.js
+++ b/src/signal/indicators/trend.core.js
@@ -1,0 +1,6 @@
+import { getTrend } from '../../strategy/trend.js';
+
+export function computeTrend(candles) {
+  return getTrend(candles);
+}
+

--- a/src/signal/indicators/trend.js
+++ b/src/signal/indicators/trend.js
@@ -1,6 +1,5 @@
 import { timeIndicator } from '../instrumentation.js';
-
-export function computeTrend(candles) { /* ... RETURN: 'up'|'down'|'range' */ }
+import { computeTrend } from './trend.core.js';
 
 export function trendInstrumented({ candles, symbol, interval, strategy }) {
   return timeIndicator({ indicator: 'trend', symbol, interval, strategy }, computeTrend, candles);


### PR DESCRIPTION
## Summary
- add type-aware validation for indicator outputs with separate numeric and categorical sets
- route indicator wrappers through real compute functions via new core modules
- allow forcing signal emission in debug endpoint and pipeline

## Testing
- `npm test`
- `npx eslint src/signal/instrumentation.js src/signal/indicators/*.js src/signal/indicators/*.core.js src/signal/generateSignals.js src/routes/debug-observ.js`
- `DEBUG_OBSERV=1 DATABASE_URL=postgres://user:pass@localhost:5432/db npm run dev` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68af1d31f2c48325a97d1b7963fea669