### PR TITLE
Use docker entrypoint for promtool and add flexible check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "wf": "node scripts/walkforward.js",
     "wf:summary": "node scripts/wf-summary.js",
     "artifacts:backfill": "node scripts/backfill-artifacts-size.js",
-    "prom:check": "docker run --rm -v \"$PWD/deploy/prometheus:/etc/prometheus\" prom/prometheus promtool check rules /etc/prometheus/alerts.yml /etc/prometheus/recording-rules.yml /etc/prometheus/alerts-burnrate.yml",
+    "prom:check": "docker run --rm -v \"$PWD/deploy/prometheus:/etc/prometheus\" --entrypoint /bin/promtool prom/prometheus:latest check rules /etc/prometheus/alerts.yml /etc/prometheus/recording-rules.yml /etc/prometheus/alerts-burnrate.yml",
+    "prom:check:min": "docker run --rm -v \"$PWD/deploy/prometheus:/etc/prometheus\" --entrypoint /bin/promtool prom/prometheus:latest check rules /etc/prometheus/alerts.yml",
     "stack:up": "docker compose -f deploy/docker-compose.observability.yml up -d prometheus alertmanager grafana",
-    "stack:logs": "docker compose -f deploy/docker-compose.observability.yml logs -f prometheus"
+    "stack:logs": "docker compose -f deploy/docker-compose.observability.yml logs -f prometheus",
+    "prom:check:flex": "./scripts/promtool.sh"
   },
   "dependencies": {
     "@opentelemetry/auto-instrumentations-node": "^0.62.1",

--- a/scripts/promtool.sh
+++ b/scripts/promtool.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROMDIR="$DIR/deploy/prometheus"
+
+FILES=()
+for f in alerts.yml recording-rules.yml alerts-burnrate.yml; do
+  [ -f "$PROMDIR/$f" ] && FILES+=("/etc/prometheus/$f")
+done
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  echo "No rule files found in $PROMDIR" >&2
+  exit 1
+fi
+
+docker run --rm \
+  -v "$PROMDIR:/etc/prometheus" \
+  --entrypoint /bin/promtool \
+  prom/prometheus:latest \
+  check rules "${FILES[@]}"
+


### PR DESCRIPTION
## Summary
- fix `prom:check` to invoke promtool via Docker entrypoint
- add `prom:check:min` and a flexible `prom:check:flex` script for existing rule files

## Testing
- `npm run prom:check` *(fails: Cannot connect to the Docker daemon)*
- `npm run prom:check:flex` *(fails: Cannot connect to the Docker daemon)*
- `npm test`
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af68d312ac83258a9e77b0f3529b12