### PR TITLE
fix(prometheus): simplify recording rule expressions

### DIFF
--- a/deploy/prometheus/recording-rules.yml
+++ b/deploy/prometheus/recording-rules.yml
@@ -3,12 +3,13 @@ groups:
   rules:
   - record: sli:api_error_ratio:rate5m
     expr: sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m]))
+
   - record: sli:api_latency_under_1s_ratio:rate5m
     expr: (sum(rate(http_request_duration_seconds_bucket{le="1"}[5m])) by ()) / (sum(rate(http_request_duration_seconds_count[5m])) by ())
+
   - record: sli:sse_ping_delivery_ratio:rate5m
-    expr: clamp_max(
-      rate(sse_events_sent_total{event="ping"}[5m]) /
-      ((avg_over_time(sse_connections[5m])) / 15)
-    , 1)
+    expr: clamp_max(rate(sse_events_sent_total{event="ping"}[5m]) / ((avg_over_time(sse_connections[5m])) / 15), 1)
+
   - record: sli:jobs_success_ratio:rate15m
-    expr: 1 - ( sum(rate(job_duration_seconds_count{status="err"}[15m])) / sum(rate(job_duration_seconds_count[15m])) )
+    expr: 1 - (sum(rate(job_duration_seconds_count{status="err"}[15m])) / sum(rate(job_duration_seconds_count[15m])))
+


### PR DESCRIPTION
## Summary
- simplify Prometheus recording rules to single-line expressions to avoid YAML issues

## Testing
- `/tmp/promtool check rules deploy/prometheus/alerts.yml deploy/prometheus/recording-rules.yml deploy/prometheus/alerts-burnrate.yml`
- `timeout 5 /tmp/prometheus-2.51.2.linux-amd64/prometheus --config.file=deploy/prometheus/prometheus.yml --storage.tsdb.path=/tmp/prom-data --web.listen-address=:9099`

------
https://chatgpt.com/codex/tasks/task_e_68af6adcd8408325aae78d49b27330a9