### PR TITLE
fix: update LRUCache import in artifactsFS

### DIFF
--- a/src/services/artifactsFS.js
+++ b/src/services/artifactsFS.js
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import LRU from 'lru-cache';
+import { LRUCache } from 'lru-cache';
 import crypto from 'crypto';
 import { ARTIFACTS_ROOT } from '../config.js';
 
-const metaCache = new LRU({ max: 500, ttl: 10 * 60 * 1000 });
+const metaCache = new LRUCache({ max: 500, ttl: 10 * 60 * 1000 });
 
 const MIME = new Map(Object.entries({
   '.csv': 'text/csv',


### PR DESCRIPTION
## Summary
- fix LRU cache import for ESM by using named `LRUCache`

## Testing
- `npm test`
- `DATABASE_URL=postgres://localhost npm run dev` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68af77f708dc8325b99c26b4a9e29227