### PR TITLE
feat: add postgres service for deploy-api

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -10,3 +10,19 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 # Telegram
 TELEGRAM_BOT_TOKEN=123456:ABCDEF...
 TELEGRAM_PRIVATE_CHAT_ID=-100xxxxxxxxxxxx
+
+# Variant A (DB hoste)
+PGHOST=host.docker.internal
+PGPORT=5432
+PGUSER=app
+PGPASSWORD=app
+PGDATABASE=crypto
+# DATABASE_URL=postgres://app:app@host.docker.internal:5432/crypto
+
+# Variant B (DB compose)
+# PGHOST=postgres
+# PGPORT=5432
+# PGUSER=app
+# PGPASSWORD=app
+# PGDATABASE=crypto
+# DATABASE_URL=postgres://app:app@postgres:5432/crypto

--- a/deploy/docker-compose.observability.yml
+++ b/deploy/docker-compose.observability.yml
@@ -1,5 +1,18 @@
-version: '3.9'
 services:
+  postgres:
+    image: postgres:15-alpine
+    ports: ["5432:5432"]
+    environment:
+      - POSTGRES_USER=app
+      - POSTGRES_PASSWORD=app
+      - POSTGRES_DB=crypto
+    volumes:
+      - ./pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d crypto"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.99.0
     command: ["--config=/etc/otel/collector-config.yaml"]
@@ -37,11 +50,20 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318/v1/traces
       DEPLOY_ENV: development
       SERVICE_NAMESPACE: crypto-signals
+      PGHOST: postgres
+      PGPORT: 5432
+      PGUSER: app
+      PGPASSWORD: app
+      PGDATABASE: crypto
     volumes:
       - ../logs:/app/logs
     depends_on:
-      - otel-collector
-      - loki
+      otel-collector:
+        condition: service_started
+      loki:
+        condition: service_started
+      postgres:
+        condition: service_healthy
     ports:
       - '3000:3000'
   alertmanager:

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -9,8 +9,9 @@ scrape_configs:
     static_configs:
       - targets: ['prometheus:9090']
   - job_name: api
+    metrics_path: /metrics
     static_configs:
-      - targets: ['deploy-api:3000']
+      - targets: ["deploy-api:3000"]
   - job_name: otel-collector
     static_configs:
       - targets: ['otel-collector:8888']

--- a/src/live.js
+++ b/src/live.js
@@ -1,5 +1,5 @@
 // src/live.js — paper trading with risk management
-import { Pool } from 'pg';
+import { db as pool } from './storage/db.js';
 import fsp from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -11,10 +11,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const clientPublicDir = path.join(__dirname, '..', 'client', 'public');
 const paramsPath = path.join(__dirname, '..', 'config', 'params.json');
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
-});
 
 const LOOP_MS = 60 * 1000;
 let loopTimer = null;

--- a/src/storage/db.js
+++ b/src/storage/db.js
@@ -1,17 +1,26 @@
 import pkg from 'pg';
 const { Pool } = pkg;
 import { readFileSync } from 'fs';
-import { cfg } from '../config.js';
 
-const connectionString = cfg.dbUrl;
-if (!connectionString) {
-  throw new Error('Missing DATABASE_URL environment variable');
+const conn = process.env.DATABASE_URL;
+
+export const db = conn
+  ? new Pool({
+      connectionString: conn,
+      ssl: { rejectUnauthorized: false },
+    })
+  : new Pool({
+      host: process.env.PGHOST,
+      port: +(process.env.PGPORT || 5432),
+      user: process.env.PGUSER,
+      password: process.env.PGPASSWORD,
+      database: process.env.PGDATABASE,
+      ssl: { rejectUnauthorized: false },
+    });
+
+if (!conn && !process.env.PGHOST) {
+  throw new Error('Missing DATABASE_URL or PG* environment variables');
 }
-
-export const db = new Pool({
-  connectionString,
-  ssl: { rejectUnauthorized: false },
-});
 
 // Subscribe to PostgreSQL LISTEN/NOTIFY channel
 // Returns a function that releases the listener


### PR DESCRIPTION
## Summary
- remove deprecated compose version key and add postgres service
- configure deploy-api to use postgres and update db pool env handling
- document database env options and scrape deploy-api metrics

## Testing
- `npm test`
- `npm run lint` *(fails: 'err' is defined but never used and other lint errors)*
- `npm run prom:check:min` *(fails: docker: not found)*
- `docker compose -f deploy/docker-compose.observability.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0899855448325858db7279f91c64b