### PR TITLE
fix: correct Grafana provisioning mounts

### DIFF
--- a/deploy/docker-compose.observability.yml
+++ b/deploy/docker-compose.observability.yml
@@ -97,8 +97,7 @@ services:
       - prometheus
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning
-      - ./grafana/dashboards:/etc/grafana/provisioning/dashboards
-      - ./grafana/provisioning/dashboards/obs.yaml:/etc/grafana/provisioning/dashboards/obs.yaml
+      - ./grafana/dashboards:/etc/grafana/dashboards
 volumes:
   loki-data:
   # logs volume for deploy-api container

--- a/grafana/provisioning/dashboards/obs.yaml
+++ b/grafana/provisioning/dashboards/obs.yaml
@@ -3,6 +3,8 @@ providers:
   - name: Observability
     folder: Observability
     type: file
-    updateIntervalSeconds: 10
+    disableDeletion: false
+    allowUiUpdates: true
     options:
-      path: /etc/grafana/provisioning/dashboards
+      path: /etc/grafana/dashboards
+


### PR DESCRIPTION
## Summary
- remove file-specific Grafana provisioning mount and map dashboards directory to `/etc/grafana/dashboards`
- update `obs.yaml` to load dashboards from new path with UI updates allowed

## Testing
- `npm test`
- `npm run lint` *(fails: window is not defined etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ad1856708325a6e3983da02687e8