### PR TITLE
Use bigint timestamps in portfolio and cleanup test teardown

### DIFF
--- a/tests/integration/with-pg.int.test.cjs
+++ b/tests/integration/with-pg.int.test.cjs
@@ -7,12 +7,17 @@ beforeAll(async () => {
   const { startPgWithSchema } = await import('../helpers/pgContainer.js');
   pgEnv = await startPgWithSchema();
   process.env.DATABASE_URL = pgEnv.DATABASE_URL;
-  process.env.NODE_ENV = 'test';
   app = (await import('../../src/server.js')).default;
 }, 60000);
 
 afterAll(async () => {
-  await pgEnv.container.stop();
+  try {
+    const { pool } = await import('../../src/storage/db.js');
+    await pool.end();
+  } catch {}
+  try {
+    await pgEnv?.container.stop();
+  } catch {}
 }, 60000);
 
 test('GET /live/equity returns series and supports ds', async () => {
@@ -23,7 +28,7 @@ test('GET /live/equity returns series and supports ds', async () => {
 });
 
 test('GET /portfolio returns holdings/allocation/risk', async () => {
-  const res = await request(app).get('/portfolio');
+  const res = await request(app).get('/portfolio?from_ms=0&to_ms=9999999');
   expect(res.status).toBe(200);
   expect(res.body).toHaveProperty('holdings');
   expect(res.body).toHaveProperty('allocation');


### PR DESCRIPTION
## Summary
- Handle epoch millisecond ranges in /portfolio by using bigint parameters and computing returns without `generate_series`
- Filter closed trades by bigint timestamps in portfolio and attribution queries
- Close database pool during integration test teardown and explicitly provide seed time range

## Testing
- `npm run test:cov` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e5e2880c8325bb78e6ef5d47c730