### PR TITLE
feat: disable server listen in tests

### DIFF
--- a/tests/integration/jobs.mvp.test.cjs
+++ b/tests/integration/jobs.mvp.test.cjs
@@ -17,13 +17,9 @@ beforeAll(async () => {
 }, 60000);
 
 afterAll(async () => {
-  try {
-    if (app && typeof app.shutdown === 'function') await app.shutdown();
-  } catch {}
-  try {
-    if (pgEnv) await pgEnv.container.stop();
-  } catch {}
-}, 60000);
+  await app?.shutdown?.();
+  await pgEnv?.container.stop();
+}, 10000);
 
 test('backtest job runs and produces artifact', async () => {
   const res = await request(app).post('/jobs/backtest').send({ symbol: 'BTCUSDT', from_ms: 0, to_ms: 4000, strategy: 'demo' });


### PR DESCRIPTION
## Summary
- guard server start so tests don't listen on a port
- cleanly shutdown server in tests

## Testing
- `npm run test:cov` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68b31eb701e483258fd1a52a53527443