### PR TITLE
chore: ignore e2e screenshot artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ client/dist/
 /crypto-signal-12245b8873c0.json
 /crypto-signal-prod-c87a61be0e72.json
 /.idea/
+
+# E2E screenshots
+tests/e2e/__screenshots__/


### PR DESCRIPTION
## Summary
- ignore Playwright screenshot artifacts

## Testing
- `npm test` *(fails: Cannot find module 'jsdom'; Could not find a working container runtime strategy; SyntaxError in e2e specs)*

------
https://chatgpt.com/codex/tasks/task_e_68b379279a4883259743f3e98faaedc4