### PR TITLE
Analytics UI v2.0 — Baseline+Overlays+Jobs (+ client tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,5 +105,22 @@ Custom metrics exported:
   - Risk halted: `risk_state.state == 'HALTED'` for >15 min (metric or log-based)
   - Jobs backlog: `jobs.queue.oldest_age_ms` > 15 min
 
+## Analytics UI v2.0
+
+The analytics dashboard is a static page served from `client/public/analytics.html`.
+Start a lightweight dev server to view it locally:
+
+```
+npm run serve:client
+```
+
+Client-side tests cover the UI logic:
+
+- `npm run test:client` – run browser-like tests in JSDOM.
+- `npm run test:cov:client` – generate client coverage reports.
+
+The page expects backend endpoints `/analytics`, `/analytics/jobs`, `/analytics/job/:id/equity`, and `/portfolio`.
+During tests these requests are mocked via `whatwg-fetch`.
+
 ## Disclaimer
 Educational purposes only. No financial advice.

--- a/client/public/analytics.html
+++ b/client/public/analytics.html
@@ -1,49 +1,74 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <title>Analytics</title>
-    <link rel="stylesheet" href="/assets/nav.css">
-    <link rel="stylesheet" href="/assets/ui-breadcrumbs.css">
-    <link rel="stylesheet" href="/assets/ui-tabs.css">
-    <link rel="stylesheet" href="/assets/ui-loader.css" />
-  </head>
-  <body data-page="Analytics">
-  <div id="app-nav"></div>
-  <div id="app-breadcrumbs"></div>
+<head>
+  <meta charset="utf-8">
+  <title>Analytics</title>
+  <link rel="stylesheet" href="/assets/nav.css">
+  <link rel="stylesheet" href="/assets/ui-breadcrumbs.css">
+  <link rel="stylesheet" href="/assets/ui-loader.css">
+  <link rel="stylesheet" href="/assets/analytics.css">
+</head>
+<body data-page="Analytics">
+<div id="app-nav"></div>
+<div id="app-breadcrumbs"></div>
+<div id="toasts"></div>
+<main class="container">
+  <fieldset class="filters">
+    <label>Symbol <input name="symbol" list="symbols" value="SOLUSDT"></label>
+    <datalist id="symbols"><option value="SOLUSDT"></option></datalist>
+    <label>Interval
+      <select name="interval">
+        <option value="1m" selected>1m</option>
+        <option value="5m">5m</option>
+        <option value="15m">15m</option>
+        <option value="1h">1h</option>
+        <option value="4h">4h</option>
+        <option value="1d">1d</option>
+      </select>
+    </label>
+    <label>From <input name="from" placeholder="ms or ISO"></label>
+    <label>To <input name="to" placeholder="ms or ISO"></label>
+    <label>Downsampling
+      <select name="ds">
+        <option value="none">none</option>
+        <option value="lttb" selected>lttb</option>
+      </select>
+    </label>
+    <label>N <input name="n" type="number" value="1000"></label>
+    <button type="button" data-apply>Apply</button>
+    <button type="button" data-reset>Reset</button>
+  </fieldset>
 
-  <main class="container">
-    <div class="ui-tabs" id="analytics-tabs" role="tablist">
-      <button role="tab" aria-controls="tab-overview" data-module="analyticsOverview">Overview</button>
-      <button role="tab" aria-controls="tab-trades" data-module="analyticsTrades" data-prefetch-url="/data/analytics-trades.json">Trades</button>
-    </div>
+  <section class="card" id="equity-card">
+    <h2>Equity (Baseline + Overlays)</h2>
+    <canvas data-equity></canvas>
+  </section>
 
-    <section id="tab-overview" role="tabpanel" tabindex="0">
-      <div id="equity-card">
-        <span data-ts></span>
-        <span class="live-badge">LIVE</span>
-        <canvas data-equity-canvas></canvas>
-      </div>
-    </section>
-    <section id="tab-trades" role="tabpanel" tabindex="0" hidden>
-      <div id="trades-panel" class="panel-body"></div>
-    </section>
-  </main>
+  <section class="card" id="overlays-card">
+    <h2>Overlays</h2>
+    <div class="overlays-list" data-overlays-list></div>
+    <a data-export-csv href="#">Export Overlays CSV</a>
+  </section>
 
-  <div id="app-footer"></div>
-    <script type="module" src="/assets/nav.js"></script>
-    <script type="module" src="/assets/ui-breadcrumbs.js"></script>
-    <script type="module" src="/assets/ui-tabs.js"></script>
-    <script type="module" src="/assets/ui-lazy.js"></script>
-    <script type="module" src="/assets/ui-loader.js"></script>
-    <script src="/assets/vendor/chart.umd.js"></script>
-    <script type="module">
-      import { freezeCanvasEnv } from '/assets/chart-globals.js';
-      if (new URLSearchParams(location.search).get('e2e') === '1') {
-        (window as any).__E2E__ = true;
-        freezeCanvasEnv();
-      }
-    </script>
-    <script type="module" src="/assets/analytics.js"></script>
-  </body>
+  <section class="card" id="jobs-card">
+    <h2>Jobs</h2>
+    <button type="button" data-jobs-refresh>Refresh</button>
+    <table data-jobs-table>
+      <thead><tr><th>id</th><th>type</th><th>symbol</th><th>strategy</th><th>status</th><th>artifacts</th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
+  <section class="card" id="stats-card">
+    <h2>Stats/Portfolio</h2>
+    <div data-portfolio></div>
+  </section>
+</main>
+<div id="app-footer"></div>
+<script type="module" src="/assets/nav.js"></script>
+<script type="module" src="/assets/ui-breadcrumbs.js"></script>
+<script type="module" src="/assets/ui-toast.js"></script>
+<script src="/assets/vendor/chart.umd.js"></script>
+<script type="module" src="/assets/analytics.js"></script>
+</body>
 </html>

--- a/client/public/assets/analytics.css
+++ b/client/public/assets/analytics.css
@@ -1,0 +1,3 @@
+.filters{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:8px;margin-bottom:12px}
+.card{border:1px solid #222;padding:12px;border-radius:8px;margin-bottom:12px;background:#111}
+.overlays-list div{margin:4px 0}

--- a/client/public/assets/analytics.js
+++ b/client/public/assets/analytics.js
@@ -1,37 +1,195 @@
-import { E2E_EQUITY } from './analytics.e2e-dataset.js';
+import { showToast } from './ui-toast.js';
 
-function getDataset() {
-  if (window.__E2E__) return Promise.resolve(E2E_EQUITY);
-  return fetch('/data/analytics-equity.json').then(r => r.json());
+const ChartLib = globalThis.Chart;
+if (ChartLib?.register && ChartLib.registerables) {
+  ChartLib.register(...ChartLib.registerables);
 }
 
-async function renderChart() {
-  const canvas = document.querySelector('[data-equity-canvas]');
-  if (!canvas || !(window as any).Chart) return;
-  const points = await getDataset();
-  const labels = points.map(p => new Date(p.ts));
-  const data = points.map(p => p.equity);
-  const cfg = {
+const state = {
+  chart: null,
+  overlays: new Map(),
+  filters: {
+    symbol: 'SOLUSDT',
+    interval: '1m',
+    from_ms: '',
+    to_ms: '',
+    ds: 'lttb',
+    n: 1000,
+  },
+};
+
+export function composeAnalyticsQuery(p) {
+  const q = new URLSearchParams();
+  if (p.symbol) q.set('symbol', p.symbol);
+  if (p.interval) q.set('interval', p.interval);
+  if (p.from_ms) q.set('from_ms', p.from_ms);
+  if (p.to_ms) q.set('to_ms', p.to_ms);
+  if (p.ds) q.set('ds', p.ds);
+  if (p.n !== undefined) q.set('n', p.n);
+  return q.toString();
+}
+
+export function normalizeEquity(list) {
+  const res = list.map(p => ({ x: Number(p.ts ?? p.ms), y: Number(p.equity) }));
+  res.sort((a, b) => a.x - b.x);
+  return res;
+}
+
+export function overlayLabel(job) {
+  return `${job.id}:${job.strategy || ''}`;
+}
+
+export function composeCsvUrl(ids, range) {
+  const q = new URLSearchParams();
+  q.set('ids', ids.join(','));
+  if (range?.from_ms) q.set('from_ms', range.from_ms);
+  if (range?.to_ms) q.set('to_ms', range.to_ms);
+  return `/analytics/overlays.csv?${q.toString()}`;
+}
+
+export function initEquityChart(ctx) {
+  return new ChartLib(ctx, {
     type: 'line',
-    data: {
-      labels,
-      datasets: [{
-        label: 'Equity',
-        data,
-        borderWidth: window.__E2E__ ? 1 : 3,
-        pointRadius: window.__E2E__ ? 0 : undefined,
-        tension: window.__E2E__ ? 0 : 0.4,
-      }],
-    },
+    data: { datasets: [] },
     options: {
-      animation: window.__E2E__ ? false : undefined,
+      parsing: false,
+      animation: false,
+      scales: {
+        x: { type: 'linear' },
+      },
     },
-  };
-  new Chart(canvas.getContext('2d'), cfg);
+  });
 }
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', renderChart);
-} else {
-  renderChart();
+export function setBaseline(series) {
+  const ds = {
+    id: 'baseline',
+    label: 'Baseline',
+    data: series,
+    borderColor: 'blue',
+    fill: false,
+  };
+  const i = state.chart.data.datasets.findIndex(d => d.id === 'baseline');
+  if (i >= 0) state.chart.data.datasets[i] = ds; else state.chart.data.datasets.push(ds);
+  state.chart.update();
+}
+
+export function upsertOverlay(id, series, label) {
+  state.overlays.set(String(id), series);
+  const ds = { id: `overlay-${id}`, label, data: series, fill: false };
+  const i = state.chart.data.datasets.findIndex(d => d.id === `overlay-${id}`);
+  if (i >= 0) state.chart.data.datasets[i] = ds; else state.chart.data.datasets.push(ds);
+  state.chart.update();
+}
+
+export function removeOverlay(id) {
+  state.overlays.delete(String(id));
+  state.chart.data.datasets = state.chart.data.datasets.filter(d => d.id !== `overlay-${id}`);
+  state.chart.update();
+}
+
+export function getChart() { return state.chart; }
+
+async function fetchJSON(url) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error('HTTP');
+  return r.json();
+}
+
+export async function fetchBaseline(doc = document) {
+  try {
+    const qs = composeAnalyticsQuery(state.filters);
+    const data = await fetchJSON(`/analytics?baseline=live&${qs}`);
+    const series = normalizeEquity(data);
+    setBaseline(series);
+  } catch {
+    showToast('Failed to load baseline', { type: 'error', doc });
+  }
+}
+
+export async function fetchOverlay(id, label, doc = document) {
+  try {
+    const data = await fetchJSON(`/analytics/job/${id}/equity`);
+    upsertOverlay(id, normalizeEquity(data), label);
+    updateCsvLink(doc);
+  } catch {
+    showToast('Failed to load overlay', { type: 'error', doc });
+  }
+}
+
+export async function fetchJobs(doc = document) {
+  try {
+    const data = await fetchJSON('/analytics/jobs?limit=20');
+    renderJobsTable(data.jobs || data, doc);
+    renderOverlayList(data.jobs || data, doc);
+  } catch {
+    showToast('Failed to load jobs', { type: 'error', doc });
+  }
+}
+
+function renderOverlayList(list, doc) {
+  const host = doc.querySelector('[data-overlays-list]');
+  if (!host) return;
+  host.innerHTML = '';
+  list.forEach(job => {
+    const wrap = doc.createElement('div');
+    const cb = doc.createElement('input');
+    cb.type = 'checkbox';
+    cb.dataset.jobId = job.id;
+    cb.addEventListener('change', e => {
+      if (cb.checked) fetchOverlay(job.id, overlayLabel(job), doc);
+      else { removeOverlay(job.id); updateCsvLink(doc); }
+    });
+    wrap.appendChild(cb);
+    const label = doc.createElement('span');
+    label.textContent = overlayLabel(job);
+    wrap.appendChild(label);
+    host.appendChild(wrap);
+  });
+}
+
+function renderJobsTable(list, doc) {
+  const tbody = doc.querySelector('[data-jobs-table] tbody');
+  if (!tbody) return;
+  tbody.innerHTML = '';
+  list.forEach(job => {
+    const tr = doc.createElement('tr');
+    tr.innerHTML = `<td>${job.id}</td><td>${job.type || ''}</td><td>${job.symbol || ''}</td><td>${job.strategy || ''}</td><td>${job.status || ''}</td><td>${(job.artifacts||[]).map(a=>`<a href="${a.url}">${a.name||'dl'}</a>`).join(', ')}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+export function updateCsvLink(doc = document) {
+  const link = doc.querySelector('[data-export-csv]');
+  if (!link) return;
+  const ids = Array.from(state.overlays.keys());
+  if (ids.length === 0) { link.href = '#'; return; }
+  link.href = composeCsvUrl(ids, { from_ms: state.filters.from_ms, to_ms: state.filters.to_ms });
+}
+
+export function init(doc = document) {
+  const canvas = doc.querySelector('[data-equity]');
+  if (!canvas) return;
+  state.chart = initEquityChart(canvas.getContext('2d'));
+  fetchBaseline(doc);
+  fetchJobs(doc);
+  const refreshBtn = doc.querySelector('[data-jobs-refresh]');
+  if (refreshBtn) refreshBtn.addEventListener('click', () => fetchJobs(doc));
+  const applyBtn = doc.querySelector('[data-apply]');
+  if (applyBtn) applyBtn.addEventListener('click', () => fetchBaseline(doc));
+  const resetBtn = doc.querySelector('[data-reset]');
+  if (resetBtn) resetBtn.addEventListener('click', () => {
+    doc.querySelector('[name=symbol]').value = 'SOLUSDT';
+    doc.querySelector('[name=interval]').value = '1m';
+    doc.querySelector('[name=from]').value = '';
+    doc.querySelector('[name=to]').value = '';
+    doc.querySelector('[name=ds]').value = 'lttb';
+    doc.querySelector('[name=n]').value = '1000';
+    state.filters = { symbol:'SOLUSDT', interval:'1m', from_ms:'', to_ms:'', ds:'lttb', n:1000 };
+    fetchBaseline(doc);
+  });
+}
+
+if (typeof window !== 'undefined' && !window.__DISABLE_AUTO_INIT__) {
+  window.addEventListener('DOMContentLoaded', () => init());
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "dotenv": "^16.4.5",
         "escape-html": "^1.0.3",
         "express": "^4.19.2",
+        "jest-canvas-mock": "^2.5.2",
         "lru-cache": "^10.2.1",
         "node-telegram-bot-api": "^0.66.0",
         "pino": "^9.9.0",
@@ -4934,6 +4935,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "license": "MIT"
+    },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
@@ -7698,6 +7705,16 @@
         }
       }
     },
+    "node_modules/jest-canvas-mock": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.2.tgz",
+      "integrity": "sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==",
+      "license": "MIT",
+      "dependencies": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "node_modules/jest-changed-files": {
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.0.5.tgz",
@@ -9100,6 +9117,15 @@
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "license": "MIT"
+    },
+    "node_modules/moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4"
+      }
     },
     "node_modules/ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "dotenv": "^16.4.5",
     "escape-html": "^1.0.3",
     "express": "^4.19.2",
+    "jest-canvas-mock": "^2.5.2",
     "lru-cache": "^10.2.1",
     "node-telegram-bot-api": "^0.66.0",
     "pino": "^9.9.0",
@@ -67,20 +68,20 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.8.2",
+    "@playwright/test": "^1.44.1",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/user-event": "^14.4.3",
     "cross-env": "^10.0.0",
     "eslint": "^8.56.0",
     "glob": "^11.0.3",
+    "http-server": "^14.1.1",
     "jest": "^30.1.1",
     "jest-environment-jsdom": "^30.1.1",
     "jsdom": "^24.0.0",
     "pg": "^8.16.3",
     "supertest": "^7.1.4",
     "testcontainers": "^11.5.1",
-    "whatwg-fetch": "^3.6.20",
-    "@playwright/test": "^1.44.1",
-    "@axe-core/playwright": "^4.8.2",
-    "http-server": "^14.1.1"
+    "whatwg-fetch": "^3.6.20"
   }
 }

--- a/tests/client/analytics.ui.test.js
+++ b/tests/client/analytics.ui.test.js
@@ -1,0 +1,96 @@
+import fs from 'fs';
+import { jest } from '@jest/globals';
+
+const html = fs.readFileSync('client/public/analytics.html', 'utf8');
+const body = html.match(/<body[^>]*>([\s\S]*)<\/body>/i)[1].replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');
+
+function setupDom() {
+  document.body.innerHTML = body;
+  window.__DISABLE_AUTO_INIT__ = true;
+  global.Chart = class {
+    constructor(ctx, cfg){ this.ctx=ctx; this.data=cfg.data; this.update=jest.fn(); }
+  };
+}
+
+function flush() { return new Promise(r => setTimeout(r, 0)); }
+
+describe('analytics ui', () => {
+  test('smoke', () => {
+    setupDom();
+    expect(document.querySelector('fieldset.filters')).toBeTruthy();
+    expect(document.querySelector('[data-equity]')).toBeTruthy();
+    expect(document.querySelector('[data-jobs-table]')).toBeTruthy();
+  });
+
+  test('compose query', async () => {
+    const mod = await import('../../client/public/assets/analytics.js');
+    const q = mod.composeAnalyticsQuery({ symbol:'SOL', interval:'1h', from_ms:1, to_ms:2, ds:'lttb', n:10 });
+    expect(q).toContain('symbol=SOL');
+    expect(q).toContain('interval=1h');
+    expect(q).toContain('n=10');
+  });
+
+  test('normalize and overlay label', async () => {
+    const mod = await import('../../client/public/assets/analytics.js');
+    const series = mod.normalizeEquity([{ts:2,equity:'2'},{ts:1,equity:'1'}]);
+    expect(series[0].x).toBe(1);
+    expect(series[1].y).toBe(2);
+    expect(mod.overlayLabel({id:5,strategy:'s'})).toBe('5:s');
+  });
+
+  test('baseline dataset added', async () => {
+    setupDom();
+    const baseline = [{ ts:1, equity:2 }];
+    const jobs = [{ id:42, strategy:'str' }];
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(new Response(JSON.stringify(baseline)));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(new Response(JSON.stringify(jobs)));
+      return Promise.reject('u');
+    });
+    jest.resetModules();
+    const mod = await import('../../client/public/assets/analytics.js');
+    mod.init(document);
+    await flush();
+    const chart = mod.getChart();
+    expect(chart.data.datasets.find(d=>d.id==='baseline')).toBeTruthy();
+  });
+
+  test('overlay add/remove and csv link', async () => {
+    setupDom();
+    const baseline = [{ ts:1, equity:2 }];
+    const jobs = [{ id:7, strategy:'A' }];
+    const overlay = [{ ts:2, equity:3 }];
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(new Response(JSON.stringify(baseline)));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(new Response(JSON.stringify(jobs)));
+      if (url === '/analytics/job/7/equity') return Promise.resolve(new Response(JSON.stringify(overlay)));
+      return Promise.reject('u');
+    });
+    jest.resetModules();
+    const mod = await import('../../client/public/assets/analytics.js');
+    mod.init(document);
+    await flush();
+    const cb = document.querySelector('[data-overlays-list] input');
+    cb.checked = true; cb.dispatchEvent(new Event('change'));
+    await flush();
+    const chart = mod.getChart();
+    expect(chart.data.datasets.length).toBe(2);
+    expect(chart.data.datasets[1].label).toBe('7:A');
+    const link = document.querySelector('[data-export-csv]');
+    expect(link.href).toContain('ids=7');
+    cb.checked = false; cb.dispatchEvent(new Event('change'));
+    await flush();
+    expect(chart.data.datasets.length).toBe(1);
+  });
+
+  test('error toast on API error', async () => {
+    setupDom();
+    global.fetch = jest.fn(() => Promise.resolve(new Response('',{ status:500 })));
+    jest.resetModules();
+    const mod = await import('../../client/public/assets/analytics.js');
+    mod.init(document);
+    await flush();
+    const toastHost = document.getElementById('toasts');
+    expect(toastHost.textContent).toMatch(/Failed to load baseline/);
+  });
+});

--- a/tests/setup/jest.setup.dom.cjs
+++ b/tests/setup/jest.setup.dom.cjs
@@ -1,4 +1,5 @@
 require('whatwg-fetch');
+require('jest-canvas-mock');
 
 if (!global.crypto) global.crypto = {};
 if (!global.crypto.randomUUID) {
@@ -7,6 +8,8 @@ if (!global.crypto.randomUUID) {
 
 class IO { observe(){} unobserve(){} disconnect(){} }
 if (!global.IntersectionObserver) global.IntersectionObserver = IO;
+class RO { observe(){} unobserve(){} disconnect(){} }
+if (!global.ResizeObserver) global.ResizeObserver = RO;
 
 if (typeof window !== 'undefined') {
   window.__DISABLE_AUTO_INIT__ = true;


### PR DESCRIPTION
## Summary
- rebuild analytics dashboard UI with filters, overlays, jobs table and export link
- add Chart-based baseline/overlay logic and helper utilities
- introduce client tests for analytics workflows and supporting setup

## Testing
- `APP_DISABLE_LISTEN=1 npm test` *(fails: Could not find a working container runtime strategy)*
- `npm run test:client`
- `npm run test:cov:client`


------
https://chatgpt.com/codex/tasks/task_e_68b385ae9370832585fcd4a6f60aaf1c