### PR TITLE
chore: add client tests workflow

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -1,0 +1,60 @@
+name: Client Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  client:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Run unit (JSDOM) tests
+        run: npm run test:client
+
+      - name: Install Playwright (Chromium)
+        run: npm run e2e:install
+
+      - name: Run E2E tests (Playwright)
+        env:
+          CI: 'true'
+        run: npm run e2e
+
+      - name: Upload Playwright report (on fail)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload test-results (screenshots/traces) (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload client coverage (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-client
+          path: coverage-client
+          if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Client Tests](https://github.com/your-org/crypto-signals/actions/workflows/client-tests.yml/badge.svg) ![Client Coverage](https://img.shields.io/badge/coverage--client-unknown-lightgrey)
+
 # Crypto Signals MVP (Stripe + React + Docker)
 
 Production-ready MVP for a crypto trading signals service.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:cov": "cross-env TZ=UTC NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "test:client": "cross-env TZ=UTC NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest -c jest.client.config.cjs",
     "test:cov:client": "cross-env TZ=UTC NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest -c jest.client.config.cjs --coverage",
+    "coverage:client": "npm run test:cov:client && node -e \"const b=require('fs').existsSync('coverage-client/coverage-summary.json')&&console.log('OK');\"",
     "test:observ": "node scripts/smoke-observ.js",
     "k6:http": "k6 run tests/k6/http-smoke.js",
     "build": "echo \"(optional) build step for FE bundling\"",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: 'tests/e2e',
+  retries: process.env.CI ? 1 : 0,
   use: {
     baseURL: 'http://localhost:4173',
     headless: true,
@@ -10,6 +11,9 @@ export default defineConfig({
     locale: 'en-US',
     colorScheme: 'dark',
     timezoneId: 'UTC',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
   },
   expect: {
     toHaveScreenshot: { maxDiffPixelRatio: 0.01, threshold: 0.5 },


### PR DESCRIPTION
## Summary
- run client JSDOM and Playwright tests in CI
- upload Playwright artifacts and client coverage
- tweak Playwright config and add coverage script and badges

## Testing
- `npm run test:client`
- `npm run coverage:client`
- `npm run e2e:install` *(fails: Download failed: server returned code 403)*
- `npm run e2e` *(fails: 5 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3884ea3488325803dc865e4324227