### PR TITLE
test: expand client coverage

### DIFF
--- a/tests/client/nav.ext.test.js
+++ b/tests/client/nav.ext.test.js
@@ -1,0 +1,27 @@
+import { initNav } from '../../client/public/assets/nav.js';
+
+describe('nav initNav', () => {
+  beforeEach(() => { document.body.innerHTML=''; });
+
+  test('activates current link and removes previous', async () => {
+    document.body.innerHTML = `<nav><a href="home.html">Home</a><a href="about.html">About</a></nav>`;
+    await initNav(document, { pathname:'/home.html' });
+    let active = document.querySelector('a[aria-current]');
+    expect(active.textContent).toBe('Home');
+    await initNav(document, { pathname:'/about.html' });
+    active = document.querySelector('a[aria-current]');
+    expect(active.textContent).toBe('About');
+    expect(document.querySelector('a[href="home.html"]').hasAttribute('aria-current')).toBe(false);
+  });
+
+  test('no match leaves nav untouched', async () => {
+    document.body.innerHTML = `<nav><a href="home.html">Home</a></nav>`;
+    await initNav(document, { pathname:'/elsewhere.html' });
+    expect(document.querySelector('a[aria-current]')).toBeNull();
+  });
+
+  test('missing nav is noop', async () => {
+    document.body.innerHTML = `<div></div>`;
+    await expect(initNav(document, { pathname:'/a.html' })).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/analytics.overlays.branch.test.js
+++ b/tests/unit/analytics.overlays.branch.test.js
@@ -1,0 +1,115 @@
+import { jest } from '@jest/globals';
+
+function createJsonResponse(obj, status = 200){
+  return new Response(JSON.stringify(obj), { status, headers:{'Content-Type':'application/json'} });
+}
+
+function flush(){ return new Promise(r=>setTimeout(r,0)); }
+
+function setupDom(){
+  document.body.innerHTML = `
+    <div id="toasts"></div>
+    <input name="symbol" value="SOLUSDT">
+    <input name="interval" value="1m">
+    <input name="from">
+    <input name="to">
+    <input name="strategy">
+    <input name="ds" value="lttb">
+    <input name="n" value="1000">
+    <button data-apply></button>
+    <button data-reset></button>
+    <canvas data-equity></canvas>
+    <div data-overlays-list></div>
+    <a data-export-csv></a>
+    <a id="csv-equity"></a>
+    <a id="csv-trades"></a>
+  `;
+  window.__DISABLE_AUTO_INIT__ = true;
+  global.Chart = class { constructor(){ this.data={ datasets: [] }; this.update=jest.fn(); this.toBase64Image=jest.fn(()=>"img"); } };
+}
+
+describe('analytics overlays extra branches', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+    delete global.fetch;
+    delete global.Chart;
+  });
+
+  test('upsert, dedupe, remove overlays', async () => {
+    setupDom();
+    const baseline = { equity:[{ ts:1, equity:1 }], links:{} };
+    const overlay = { equity:[{ ts:2, equity:3 }] };
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
+      if (url === '/analytics/job/1/equity') return Promise.resolve(createJsonResponse(overlay));
+      return Promise.reject('unknown');
+    });
+    const mod = await import('../../client/public/assets/analytics.js');
+    mod.init(document);
+    await flush();
+    await mod.fetchOverlay(1, 'job-1', document);
+    await flush();
+    let chart = mod.getChart();
+    expect(chart.data.datasets.length).toBe(2);
+    // duplicate overlay
+    await mod.fetchOverlay(1, 'job-1', document);
+    expect(chart.data.datasets.filter(d=>d.id==='overlay-1').length).toBe(1);
+    // remove
+    mod.removeOverlay(1);
+    expect(chart.data.datasets.find(d=>d.id==='overlay-1')).toBeUndefined();
+  });
+
+  test('fetchOverlay errors and bad payload', async () => {
+    setupDom();
+    const baseline = { equity:[{ ts:1, equity:1 }], links:{} };
+    const jobs = [];
+    let calls = 0;
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse(jobs));
+      if (url === '/analytics/job/2/equity'){
+        calls++; if (calls===1) return Promise.resolve(new Response('',{status:404}));
+        return Promise.resolve(createJsonResponse({ equity:null }));
+      }
+      return Promise.reject('u');
+    });
+    const mod = await import('../../client/public/assets/analytics.js');
+    mod.init(document);
+    await flush();
+    await mod.fetchOverlay(2, 'bad', document);
+    await flush();
+    expect(document.querySelector('.toast.error')).toBeTruthy();
+    await mod.fetchOverlay(2, 'bad', document);
+    await flush();
+    // still only baseline dataset
+    const chart = mod.getChart();
+    expect(chart.data.datasets.length).toBe(1);
+  });
+
+  test('updateCsvLink builds href from filters', async () => {
+    setupDom();
+    const baseline = { equity:[{ ts:1, equity:1 }], links:{} };
+    const overlay = { equity:[{ ts:2, equity:3 }] };
+    const helpers = await import('../../client/assets/analytics.helpers.js');
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
+      if (url === '/analytics/job/3/equity') return Promise.resolve(createJsonResponse(overlay));
+      return Promise.reject('u');
+    });
+    const mod = await import('../../client/public/assets/analytics.js');
+    mod.init(document);
+    await flush();
+    await mod.fetchOverlay(3, 'job-3', document);
+    document.querySelector('[name=from]').value = '10';
+    document.querySelector('[name=to]').value = '20';
+    document.querySelector('[data-apply]').click();
+    await flush();
+    mod.updateCsvLink(document);
+    const href = document.querySelector('[data-export-csv]').getAttribute('href');
+    const expected = helpers.composeCsvUrl(['3'], { from_ms:'10', to_ms:'20' });
+    expect(href).toBe(expected);
+  });
+});

--- a/tests/unit/analytics.overview.calc.test.js
+++ b/tests/unit/analytics.overview.calc.test.js
@@ -1,0 +1,31 @@
+import { jest } from '@jest/globals';
+
+function setup(){
+  document.body.innerHTML = '<div id="root"></div>';
+  global.Chart = class { constructor(){ this.data={ datasets: [] }; this.update=jest.fn(); this.toBase64Image=jest.fn(()=>"img"); } };
+}
+
+function flush(){ return new Promise(r=>setTimeout(r,0)); }
+
+describe('analytics overview calculations', () => {
+  beforeEach(() => { jest.clearAllMocks(); document.body.innerHTML=''; delete global.Chart; });
+
+  test('renders with deltas and handles edge/noise', async () => {
+    setup();
+    const root = document.getElementById('root');
+    const { mount } = await import('../../client/public/assets/modules/analytics/overview.js');
+    const api = await mount(root);
+    const overlay = { jobId:1, label:'A', equity:[{ts:1,equity:100},{ts:2,equity:130}] };
+    const baseline = { equity:[{ts:1,equity:100},{ts:2,equity:120}] };
+    window.dispatchEvent(new CustomEvent('analytics:overlays:v2', { detail:{ items:[overlay], baseline } }));
+    expect(window.AnalyticsChart.data.datasets.length).toBe(2);
+    expect(window.AnalyticsChart.data.datasets[1].label).toMatch(/ΔR/);
+    // noise - NaN equity handled without crash
+    window.dispatchEvent(new CustomEvent('analytics:overlays:v2', { detail:{ items:[{ jobId:2, label:'B', equity:[{ts:1,equity:NaN}]}], baseline:null } }));
+    expect(window.AnalyticsChart.data.datasets[0].label).toBe('B');
+    // edge clear
+    window.dispatchEvent(new Event('analytics:overlay:clear'));
+    expect(window.AnalyticsChart.data.datasets.length).toBe(0);
+    api.unmount();
+  });
+});

--- a/tests/unit/chart-globals.test.js
+++ b/tests/unit/chart-globals.test.js
@@ -1,0 +1,20 @@
+import { freezeCanvasEnv } from '../../client/public/assets/chart-globals.js';
+import { jest } from '@jest/globals';
+
+describe('chart-globals freezeCanvasEnv', () => {
+  test('fixes env when Chart present', () => {
+    const win = { __E2E__: true, Chart:{ defaults:{ animation:true } } };
+    const doc = { createElement: () => ({ textContent:'', }), head:{ appendChild: jest.fn() } };
+    freezeCanvasEnv(win, doc);
+    expect(win.Chart.defaults.animation).toBe(false);
+    const t = new win.Date();
+    expect(t.getTime()).toBe(new Date('2024-01-02T03:04:05.000Z').getTime());
+    expect(doc.head.appendChild).toHaveBeenCalled();
+  });
+
+  test('handles missing Chart', () => {
+    const win = { __E2E__: true };
+    const doc = { createElement: () => ({ textContent:'', }), head:{ appendChild: jest.fn() } };
+    expect(() => freezeCanvasEnv(win, doc)).not.toThrow();
+  });
+});

--- a/tests/unit/ui-loader.test.js
+++ b/tests/unit/ui-loader.test.js
@@ -1,0 +1,27 @@
+import '../../client/public/assets/ui-loader.js';
+import { jest } from '@jest/globals';
+
+describe('ui-loader', () => {
+  beforeEach(() => { document.body.innerHTML=''; jest.clearAllMocks(); });
+
+  test('show and hide loader', () => {
+    const div = document.createElement('div');
+    window.UILoader.show(div);
+    expect(div.querySelector('.ui-loader-stack')).toBeTruthy();
+    window.UILoader.hide(div);
+    expect(div.innerHTML).toBe('');
+  });
+
+  test('double hide no error', () => {
+    const div = document.createElement('div');
+    window.UILoader.show(div);
+    window.UILoader.hide(div);
+    expect(() => window.UILoader.hide(div)).not.toThrow();
+    expect(div.innerHTML).toBe('');
+  });
+
+  test('missing container is noop', () => {
+    expect(() => window.UILoader.show(null)).not.toThrow();
+    expect(() => window.UILoader.hide(undefined)).not.toThrow();
+  });
+});

--- a/tests/unit/ui-toast.branches.test.js
+++ b/tests/unit/ui-toast.branches.test.js
@@ -1,0 +1,31 @@
+import { initToast, showToast } from '../../client/public/assets/ui-toast.js';
+import { jest } from '@jest/globals';
+
+jest.useFakeTimers();
+
+describe('ui-toast branches', () => {
+  beforeEach(() => { document.body.innerHTML=''; jest.clearAllMocks(); });
+
+  test('error toast without delay', () => {
+    document.body.innerHTML = '<div id="toasts"></div>';
+    initToast(document);
+    showToast('err', { type:'error', timeout:0, doc:document });
+    expect(document.querySelector('.toast.error')).toBeTruthy();
+    jest.advanceTimersByTime(1);
+    expect(document.querySelector('.toast.error')).toBeNull();
+  });
+
+  test('info toast auto hides with default', () => {
+    document.body.innerHTML = '<div id="toasts"></div>';
+    initToast(document);
+    showToast('info', { type:'info', doc:document });
+    expect(document.querySelector('.toast.info')).toBeTruthy();
+    jest.advanceTimersByTime(3100);
+    expect(document.querySelector('.toast.info')).toBeNull();
+  });
+
+  test('no host is noop', () => {
+    showToast('msg');
+    expect(document.body.innerHTML).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add overlay branch tests covering error cases and CSV link updates
- exercise overview module rendering and noise handling
- add coverage tests for loader, nav, toast, and chart globals modules

## Testing
- `npm run test:cov:client`

------
https://chatgpt.com/codex/tasks/task_e_68b7809e15b48325aee74ec341702eeb