### PR TITLE
test: increase client coverage

### DIFF
--- a/tests/client/nav.auto.test.js
+++ b/tests/client/nav.auto.test.js
@@ -1,0 +1,47 @@
+import { jest } from '@jest/globals';
+
+function json(obj){ return new Response(JSON.stringify(obj), { status:200, headers:{'Content-Type':'application/json'} }); }
+function text(str){ return new Response(str, { status:200, headers:{'Content-Type':'text/html'} }); }
+function flush(){ return new Promise(r=>setTimeout(r,0)); }
+
+describe('nav auto init', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <div id="app-nav"></div>
+      <div id="app-breadcrumbs"></div>
+      <div id="app-footer"></div>
+      <div class="nav__burger"></div>
+      <div class="nav__links"></div>
+      <div id="app-version"></div>
+    `;
+    window.__DISABLE_AUTO_INIT__ = false;
+    global.fetch = jest.fn(url => {
+      if (url === '/partials/nav.html') return Promise.resolve(text('<nav><a href="home.html">Home</a></nav>'));
+      if (url === '/partials/breadcrumbs.html') return Promise.resolve(text('<span>bc</span>'));
+      if (url === '/partials/footer.html') return Promise.resolve(text('<footer>f</footer>'));
+      if (url === '/version') return Promise.resolve(json({ version:'1.2.3', commit:'abcdef0' }));
+      return Promise.resolve(text(''));
+    });
+  });
+
+  test('injects fragments and toggles burger', async () => {
+    await import('../../client/public/assets/nav.js');
+    window.dispatchEvent(new Event('DOMContentLoaded'));
+    await flush();
+    expect(document.querySelector('#app-nav nav')).toBeTruthy();
+    expect(document.body.innerHTML).toContain('<span>bc</span>');
+    expect(document.querySelector('#app-footer footer')).toBeTruthy();
+    // burger
+    const burger = document.querySelector('.nav__burger');
+    const links = document.querySelector('.nav__links');
+    burger.click();
+    expect(links.classList.contains('open')).toBe(true);
+    expect(burger.getAttribute('aria-expanded')).toBe('true');
+    burger.click();
+    expect(links.classList.contains('open')).toBe(false);
+    expect(burger.getAttribute('aria-expanded')).toBe('false');
+    // version
+    expect(document.getElementById('app-version').textContent).toMatch('1.2.3');
+  });
+});

--- a/tests/unit/analytics.overlays.branches.test.js
+++ b/tests/unit/analytics.overlays.branches.test.js
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals';
+
+function json(obj){ return new Response(JSON.stringify(obj), { status:200, headers:{'Content-Type':'application/json'} }); }
+function flush(){ return new Promise(r=>setTimeout(r,0)); }
+
+describe('analytics overlays module branches', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML='';
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } addEventListener(){} };
+    global.Toast = { open: jest.fn(), close: jest.fn() };
+  });
+
+  async function mountWithFetch(fetchImpl){
+    global.fetch = fetchImpl;
+    const root = document.createElement('div');
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
+    await mount(root);
+    return root;
+  }
+
+  test('guarded actions show warnings', async () => {
+    const root = await mountWithFetch(jest.fn(url => {
+      if (url.startsWith('/analytics/overlay-sets')) return Promise.resolve(json({ sets: [] }));
+      return Promise.resolve(json({}));
+    }));
+    root.querySelector('#ov-export').click();
+    root.querySelector('#ov-share').click();
+    root.querySelector('#ov-top-load').click();
+    root.querySelector('#ov-top-inline').click();
+    root.querySelector('#ov-set-save').click();
+    expect(global.Toast.open).toHaveBeenCalledTimes(5);
+    expect(global.Toast.open.mock.calls.map(c=>c[0].title)).toEqual([
+      'Select jobs first',
+      'Select jobs first',
+      'Optimize job ID required',
+      'Optimize job ID required',
+      'Name required'
+    ]);
+  });
+
+  test('loadJobs error triggers toast', async () => {
+    const root = await mountWithFetch(jest.fn(url => {
+      if (url.startsWith('/analytics/overlay-sets')) return Promise.resolve(json({ sets: [] }));
+      if (url.startsWith('/analytics/jobs')) return Promise.reject(new Error('fail'));
+      return Promise.resolve(json({}));
+    }));
+    root.querySelector('#ov-load').click();
+    await flush();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Failed to load jobs' }));
+  });
+});

--- a/tests/unit/ui-loader.branches.test.js
+++ b/tests/unit/ui-loader.branches.test.js
@@ -1,0 +1,30 @@
+import '../../client/public/assets/ui-loader.js';
+import { jest } from '@jest/globals';
+
+describe('ui-loader extra branches', () => {
+  beforeEach(() => { document.body.innerHTML=''; jest.clearAllMocks(); });
+
+  test.each([
+    { type:'text', count:2 },
+    { type:'title' },
+    { type:'rect', count:1 },
+    { type:'circle' },
+    { type:'row', count:1 },
+    { type:'table', rows:2 },
+    { type:'unknown', count:1 },
+  ])('renderSkeleton handles %o', spec => {
+    const div = document.createElement('div');
+    window.UILoader.renderSkeleton(div, spec);
+    expect(div.querySelector('.ui-loader-stack')).toBeTruthy();
+  });
+
+  test('withLoader success and failure', async () => {
+    const div = document.createElement('div');
+    const val = await window.UILoader.withLoader(div, async () => 5, { type:'text', count:1 });
+    expect(val).toBe(5);
+    expect(div.innerHTML).toBe('');
+    await expect(window.UILoader.withLoader(div, async () => { throw new Error('x'); }))
+      .rejects.toThrow('x');
+    expect(div.innerHTML).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add nav auto-init test covering DOM injection and burger interactions
- cover UI loader skeleton types and withLoader error handling
- exercise analytics overlays module guards for export/share/top N/save and load errors

## Testing
- `npm run test:cov:client`

------
https://chatgpt.com/codex/tasks/task_e_68b788a1a4108325b74e9699d61e9289