### PR TITLE
Improve client test coverage and generate summary

### DIFF
--- a/jest.client.config.cjs
+++ b/jest.client.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
     '\\.(css|less|scss)$': '<rootDir>/tests/setup/styleStub.js',
   },
   coverageDirectory: 'coverage-client',
+  coverageReporters: ['text', 'text-summary', 'json-summary', 'lcov'],
   collectCoverageFrom: [
     'client/assets/**/*.js',
     'client/public/**/*.js',

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:client": "cross-env TZ=UTC NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest -c jest.client.config.cjs",
     "test:cov:client": "cross-env TZ=UTC NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest -c jest.client.config.cjs --coverage",
     "coverage:client": "npm run test:cov:client && node -e \"const b=require('fs').existsSync('coverage-client/coverage-summary.json')&&console.log('OK');\"",
+    "coverage:client:json": "npm run test:cov:client && test -f coverage-client/coverage-summary.json && echo OK || (echo 'NO coverage-summary.json' && exit 1)",
     "test:observ": "node scripts/smoke-observ.js",
     "k6:http": "k6 run tests/k6/http-smoke.js",
     "build": "echo \"(optional) build step for FE bundling\"",

--- a/tests/unit/analytics.overlays.branch.test.js
+++ b/tests/unit/analytics.overlays.branch.test.js
@@ -31,6 +31,7 @@ function setupDom(){
 describe('analytics overlays extra branches', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetModules();
     document.body.innerHTML = '';
     delete global.fetch;
     delete global.Chart;
@@ -111,5 +112,22 @@ describe('analytics overlays extra branches', () => {
     const href = document.querySelector('[data-export-csv]').getAttribute('href');
     const expected = helpers.composeCsvUrl(['3'], { from_ms:'10', to_ms:'20' });
     expect(href).toBe(expected);
+  });
+
+  test('updateCsvLink handles missing link and ids', async () => {
+    setupDom();
+    const baseline = { equity:[{ ts:1, equity:1 }], links:{} };
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
+      return Promise.reject('u');
+    });
+    const mod = await import('../../client/public/assets/analytics.js');
+    mod.init(document);
+    await flush();
+    mod.updateCsvLink(document);
+    expect(document.querySelector('[data-export-csv]').getAttribute('href')).toBe('#');
+    document.querySelector('[data-export-csv]').remove();
+    expect(() => mod.updateCsvLink(document)).not.toThrow();
   });
 });

--- a/tests/unit/analytics.overlays.branches.test.js
+++ b/tests/unit/analytics.overlays.branches.test.js
@@ -49,4 +49,71 @@ describe('analytics overlays module branches', () => {
     await flush();
     expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Failed to load jobs' }));
   });
+
+  test('applyOverlays success and missing', async () => {
+    const fetchImpl = jest.fn(url => {
+      if (url.startsWith('/analytics/overlay-sets')) return Promise.resolve(json({ sets: [] }));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[{ id:1, type:'backtest' }] }));
+      if (url.startsWith('/analytics?overlay_job_ids=1')) {
+        return Promise.resolve(json({ overlayEquities:[{ jobId:1, label:'A', equity:[] }], overlayStatsByJobId:{}, baseline:null }));
+      }
+      return Promise.resolve(json({}));
+    });
+    const root = await mountWithFetch(fetchImpl);
+    root.querySelector('#ov-load').click();
+    await flush();
+    const cb = root.querySelector('#ov-jobs input[data-id="1"]');
+    cb.checked = true; cb.dispatchEvent(new Event('change'));
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+    root.querySelector('#ov-apply').click();
+    await flush();
+    expect(dispatchSpy).toHaveBeenCalled();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Overlays applied' }));
+    dispatchSpy.mockRestore();
+
+    // second call with missing equity
+    fetchImpl.mockImplementation(url => {
+      if (url.startsWith('/analytics/overlay-sets')) return Promise.resolve(json({ sets: [] }));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[{ id:1, type:'backtest' }] }));
+      if (url.startsWith('/analytics?overlay_job_ids=1')) {
+        return Promise.resolve(json({ overlayEquities:[], overlayStatsByJobId:{}, baseline:null }));
+      }
+      return Promise.resolve(json({}));
+    });
+    root.querySelector('#ov-apply').click();
+    await flush();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'No equity for jobs: 1' }));
+  });
+
+  test('clear/export/share flows', async () => {
+    const fetchImpl = jest.fn(url => {
+      if (url.startsWith('/analytics/overlay-sets')) return Promise.resolve(json({ sets: [] }));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[{ id:1, type:'backtest' }] }));
+      if (url.startsWith('/analytics?overlay_job_ids=1')) return Promise.resolve(json({ overlayEquities:[{ jobId:1, label:'A', equity:[] }] }));
+      if (url === '/analytics/overlays/share') return Promise.resolve(json({ url:'/x' }));
+      return Promise.resolve(json({}));
+    });
+    const root = await mountWithFetch(fetchImpl);
+    root.querySelector('#ov-load').click();
+    await flush();
+    const cb = root.querySelector('#ov-jobs input[data-id="1"]');
+    cb.checked = true; cb.dispatchEvent(new Event('change'));
+
+    // exportCsv
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(()=>{});
+    root.querySelector('#ov-export').click();
+    expect(openSpy).toHaveBeenCalledWith('/analytics/overlays.csv?job_ids=1', '_blank');
+    openSpy.mockRestore();
+
+    // shareUrl
+    const clip = { writeText: jest.fn().mockResolvedValue() };
+    Object.assign(navigator, { clipboard: clip });
+    root.querySelector('#ov-share').click();
+    await flush();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'URL copied' }));
+
+    // clearAll
+    root.querySelector('#ov-clear').click();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Overlays cleared' }));
+  });
 });

--- a/tests/unit/analytics.overview.calc.test.js
+++ b/tests/unit/analytics.overview.calc.test.js
@@ -28,4 +28,19 @@ describe('analytics overview calculations', () => {
     expect(window.AnalyticsChart.data.datasets.length).toBe(0);
     api.unmount();
   });
+
+  test('align first-common and rebase', async () => {
+    setup();
+    const root = document.getElementById('root');
+    const { mount } = await import('../../client/public/assets/modules/analytics/overview.js');
+    await mount(root);
+    const items = [
+      { jobId:1, label:'A', equity:[{ts:1,equity:100},{ts:3,equity:200}] },
+      { jobId:2, label:'B', equity:[{ts:2,equity:50},{ts:3,equity:75}] }
+    ];
+    window.dispatchEvent(new CustomEvent('analytics:overlays:v2', { detail:{ items, baseline:null, settings:{ align:'first-common', rebase:100 } } }));
+    expect(window.AnalyticsChart.data.datasets.length).toBe(2);
+    expect(window.AnalyticsChart.data.datasets[0].data[0]).toEqual({ x:3, y:100 });
+    expect(window.AnalyticsChart.data.datasets[1].data[0]).toEqual({ x:3, y:100 });
+  });
 });


### PR DESCRIPTION
## Summary
- add JSON coverage reporter and helper script for client tests
- expand analytics overlay tests for apply/export/share flows and CSV link safety
- cover overview alignment and rebase scenarios

## Testing
- `npm run coverage:client:json`


------
https://chatgpt.com/codex/tasks/task_e_68b78b88f8588325b8a1b15b1e2f948c