### PR TITLE
test: expand analytics overlay coverage

### DIFF
--- a/tests/client/analytics.updateCsvLink.fallback.test.js
+++ b/tests/client/analytics.updateCsvLink.fallback.test.js
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals';
+
+const helpersMock = {
+  composeAnalyticsQuery: jest.fn(),
+  normalizeEquity: jest.fn(),
+  overlayLabel: jest.fn(),
+  composeCsvUrl: jest.fn(() => '#'),
+};
+
+jest.unstable_mockModule('../../client/assets/analytics.helpers.js', () => helpersMock);
+
+function setupDom(){
+  document.body.innerHTML = '<div id="toasts"></div><a data-export-csv href="#"></a>';
+  global.Chart = class { constructor(){ this.data={datasets:[]}; this.update=jest.fn(); } };
+}
+
+describe('updateCsvLink fallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML='';
+    delete global.Chart;
+    window.__DISABLE_AUTO_INIT__ = true;
+  });
+
+  test('missing link is safe', async () => {
+    setupDom();
+    const Analytics = await import('../../client/public/assets/analytics.js');
+    Analytics.initEquityChart({});
+    document.querySelector('[data-export-csv]').remove();
+    expect(() => Analytics.updateCsvLink(document)).not.toThrow();
+  });
+
+  test('no overlays leads to # and empty compose call', async () => {
+    setupDom();
+    const Analytics = await import('../../client/public/assets/analytics.js');
+    Analytics.initEquityChart({});
+    Analytics.updateCsvLink(document);
+    expect(helpersMock.composeCsvUrl).toHaveBeenCalledWith([], { from_ms:'', to_ms:'' });
+    expect(document.querySelector('[data-export-csv]').getAttribute('href')).toBe('#');
+  });
+});

--- a/tests/unit/analytics.overlays.api-errors.test.js
+++ b/tests/unit/analytics.overlays.api-errors.test.js
@@ -1,0 +1,46 @@
+import { jest } from '@jest/globals';
+
+function json(obj, status=200){ return new Response(JSON.stringify(obj), { status, headers:{'Content-Type':'application/json'} }); }
+function flush(){ return new Promise(r=>setTimeout(r,0)); }
+
+describe('analytics overlays api errors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    document.body.innerHTML='';
+    delete global.fetch;
+    delete global.Toast;
+  });
+
+  test('handles loadJobs and applyOverlays errors', async () => {
+    global.Toast = { open: jest.fn(), close: jest.fn() };
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } };
+    // first mount: loadJobs error
+    global.fetch = jest.fn(() => Promise.resolve(new Response('', { status:500 })));
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
+    const root = document.createElement('div');
+    await mount(root);
+    root.querySelector('#ov-load').click();
+    await flush();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Failed to load jobs', variant:'error' }));
+
+    // remount for applyOverlays error
+    jest.resetModules();
+    global.Toast.open.mockClear();
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[{id:1,type:'backtest',params:{},result:{}}] }));
+      if (url.startsWith('/analytics?overlay_job_ids=1')) return Promise.resolve(new Response('', { status:500 }));
+      return Promise.resolve(json({}));
+    });
+    document.body.innerHTML='';
+    const root2 = document.createElement('div');
+    await mount(root2);
+    root2.querySelector('#ov-load').click();
+    await flush();
+    const cb = root2.querySelector('#ov-jobs input[data-id="1"]');
+    cb.checked=true; cb.dispatchEvent(new Event('change'));
+    root2.querySelector('#ov-apply').click();
+    await flush();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Apply failed', variant:'error' }));
+  });
+});

--- a/tests/unit/analytics.overlays.csv-link.test.js
+++ b/tests/unit/analytics.overlays.csv-link.test.js
@@ -1,0 +1,34 @@
+import { jest } from '@jest/globals';
+
+function json(obj, status=200){ return new Response(JSON.stringify(obj), { status, headers:{'Content-Type':'application/json'} }); }
+function flush(){ return new Promise(r=>setTimeout(r,0)); }
+
+describe('analytics overlays csv link', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    document.body.innerHTML='';
+    delete global.fetch;
+    delete global.Toast;
+  });
+
+  test('export csv builds url with ids', async () => {
+    global.Toast = { open: jest.fn(), close: jest.fn() };
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } };
+    window.open = jest.fn();
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[{id:1},{id:2}] }));
+      return Promise.resolve(json({ overlayEquities:[], overlayStatsByJobId:{} }));
+    });
+    const root = document.createElement('div');
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
+    await mount(root);
+    root.querySelector('#ov-load').click();
+    await flush();
+    const boxes = root.querySelectorAll('#ov-jobs input[data-id]');
+    boxes[0].checked=true; boxes[0].dispatchEvent(new Event('change'));
+    boxes[1].checked=true; boxes[1].dispatchEvent(new Event('change'));
+    root.querySelector('#ov-export').click();
+    expect(window.open).toHaveBeenCalledWith('/analytics/overlays.csv?job_ids=1,2', '_blank');
+  });
+});

--- a/tests/unit/analytics.overlays.guards.test.js
+++ b/tests/unit/analytics.overlays.guards.test.js
@@ -1,0 +1,57 @@
+import { jest } from '@jest/globals';
+
+function json(obj, status=200){ return new Response(JSON.stringify(obj), { status, headers:{ 'Content-Type':'application/json' }}); }
+function flush(){ return new Promise(r=>setTimeout(r,0)); }
+
+describe('analytics overlays guards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    document.body.innerHTML='';
+    delete global.fetch;
+    delete global.Toast;
+  });
+
+  test('apply/export/share guards and max overlays', async () => {
+    global.Toast = { open: jest.fn(), close: jest.fn() };
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } };
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics/jobs')){
+        const jobs = Array.from({ length:6 }, (_,i)=>({ id:i+1, type:'backtest', params:{}, result:{} }));
+        return Promise.resolve(json({ jobs }));
+      }
+      if (url.startsWith('/analytics/overlays/share')){
+        return Promise.resolve(json({ url:'/s' }));
+      }
+      if (url.startsWith('/analytics?overlay_job_ids')){
+        return Promise.resolve(json({ overlayEquities:[], overlayStatsByJobId:{} }));
+      }
+      return Promise.resolve(json({}));
+    });
+    window.open = jest.fn();
+    const root = document.createElement('div');
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
+    await mount(root);
+
+    // apply without selection
+    root.querySelector('#ov-apply').click();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Select jobs first', variant:'warning' }));
+
+    // export without selection
+    root.querySelector('#ov-export').click();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Select jobs first', variant:'warning' }));
+
+    // share without selection
+    root.querySelector('#ov-share').click();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Select jobs first', variant:'warning' }));
+
+    // load jobs and exceed max
+    root.querySelector('#ov-load').click();
+    await flush();
+    const boxes = root.querySelectorAll('#ov-jobs input[data-id]');
+    for (let i=0;i<5;i++){ boxes[i].checked=true; boxes[i].dispatchEvent(new Event('change')); }
+    boxes[5].checked=true; boxes[5].dispatchEvent(new Event('change'));
+    expect(boxes[5].checked).toBe(false);
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Max 5 overlays', variant:'warning' }));
+  });
+});

--- a/tests/unit/analytics.overlays.ui-events.test.js
+++ b/tests/unit/analytics.overlays.ui-events.test.js
@@ -1,0 +1,36 @@
+import { jest } from '@jest/globals';
+
+function json(obj, status=200){ return new Response(JSON.stringify(obj), { status, headers:{'Content-Type':'application/json'} }); }
+function flush(){ return new Promise(r=>setTimeout(r,0)); }
+
+describe('analytics overlays ui events', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    document.body.innerHTML='';
+    delete global.fetch;
+    delete global.Toast;
+  });
+
+  test('queue topN backtest via UI', async () => {
+    global.Toast = { open: jest.fn(), close: jest.fn() };
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } };
+    const fetchMock = jest.fn(url => {
+      if (url.startsWith('/analytics/optimize/123/top')) return Promise.resolve(json({ top:[{ cagr:1, a:2 }] }));
+      if (url === '/jobs') return Promise.resolve(json({ id:5 }));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[] }));
+      return Promise.resolve(json({}));
+    });
+    global.fetch = fetchMock;
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
+    const root = document.createElement('div');
+    await mount(root);
+    root.querySelector('#ov-top-id').value = '123';
+    root.querySelector('#ov-top-load').click();
+    await flush();
+    const btn = root.querySelector('#ov-top-results button[data-idx="0"]');
+    btn.click();
+    await flush();
+    expect(fetchMock).toHaveBeenCalledWith('/jobs', expect.any(Object));
+  });
+});

--- a/tests/unit/analytics.overlays.upsert-remove.test.js
+++ b/tests/unit/analytics.overlays.upsert-remove.test.js
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+
+function json(obj, status=200){ return new Response(JSON.stringify(obj), { status, headers:{'Content-Type':'application/json'} }); }
+function flush(){ return new Promise(r=>setTimeout(r,0)); }
+
+describe('analytics overlays upsert/remove', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    document.body.innerHTML='';
+    delete global.fetch;
+    delete global.Toast;
+  });
+
+  test('select apply and clear overlays', async () => {
+    global.Toast = { open: jest.fn(), close: jest.fn() };
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } };
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[{ id:1, type:'backtest', params:{}, result:{} }] }));
+      if (url.startsWith('/analytics?overlay_job_ids=1')) return Promise.resolve(json({ overlayEquities:[{ jobId:1, equity:[{ts:1,equity:1}] }], overlayStatsByJobId:{1:{return:0,maxDD:0}} }));
+      return Promise.resolve(json({}));
+    });
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+    const root = document.createElement('div');
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
+    await mount(root);
+    root.querySelector('#ov-load').click();
+    await flush();
+    const cb = root.querySelector('#ov-jobs input[data-id="1"]');
+    cb.checked=true; cb.dispatchEvent(new Event('change'));
+    root.querySelector('#ov-apply').click();
+    await flush();
+    expect(global.fetch).toHaveBeenCalledWith('/analytics?overlay_job_ids=1');
+    expect(dispatchSpy).toHaveBeenCalledWith(expect.any(CustomEvent));
+    // clear all overlays
+    root.querySelector('#ov-clear').click();
+    expect(dispatchSpy).toHaveBeenCalledWith(expect.objectContaining({ type:'analytics:overlay:clear' }));
+    // apply again should warn
+    root.querySelector('#ov-apply').click();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Select jobs first', variant:'warning' }));
+  });
+});

--- a/tests/unit/chart-globals.register.test.js
+++ b/tests/unit/chart-globals.register.test.js
@@ -1,0 +1,15 @@
+import { jest } from '@jest/globals';
+
+describe('chart globals register', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    delete global.Chart;
+  });
+
+  test('registers chart registerables on analytics import', async () => {
+    const register = jest.fn();
+    global.Chart = { register, registerables:[1,2] };
+    await import('../../client/public/assets/analytics.js');
+    expect(register).toHaveBeenCalledWith(1,2);
+  });
+});

--- a/tests/unit/ui-toast.defaults.test.js
+++ b/tests/unit/ui-toast.defaults.test.js
@@ -1,0 +1,22 @@
+import { jest } from '@jest/globals';
+import { showToast } from '../../client/public/assets/ui-toast.js';
+
+describe('ui-toast defaults', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '<div id="toasts"></div>';
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('uses default type and auto hides', () => {
+    showToast('hi');
+    const t = document.querySelector('.toast.info');
+    expect(t).toBeTruthy();
+    jest.advanceTimersByTime(3000);
+    expect(document.querySelector('.toast')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add guard tests for analytics overlays flow
- cover overlay CSV export, API errors, and UI event flows
- add utility tests for updateCsvLink, Chart registration, and default toasts

## Testing
- `npm run coverage:client:json`

------
https://chatgpt.com/codex/tasks/task_e_68b8509ef248832583dcfd8b8fca35f9