### PR TITLE
Expand analytics overlay test coverage

### DIFF
--- a/tests/client/analytics.updateCsvLink.fallback.test.js
+++ b/tests/client/analytics.updateCsvLink.fallback.test.js
@@ -1,41 +1,31 @@
 import { jest } from '@jest/globals';
+import 'jest-canvas-mock';
 
-const helpersMock = {
-  composeAnalyticsQuery: jest.fn(),
-  normalizeEquity: jest.fn(),
-  overlayLabel: jest.fn(),
-  composeCsvUrl: jest.fn(() => '#'),
-};
-
-jest.unstable_mockModule('../../client/assets/analytics.helpers.js', () => helpersMock);
-
-function setupDom(){
-  document.body.innerHTML = '<div id="toasts"></div><a data-export-csv href="#"></a>';
-  global.Chart = class { constructor(){ this.data={datasets:[]}; this.update=jest.fn(); } };
-}
-
-describe('updateCsvLink fallback', () => {
+describe('analytics.updateCsvLink fallback branches', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     document.body.innerHTML='';
-    delete global.Chart;
-    window.__DISABLE_AUTO_INIT__ = true;
+    global.Chart = class { constructor(){ this.data={ datasets:[] }; this.update=jest.fn(); } };
   });
+  afterEach(() => { delete global.Chart; });
 
-  test('missing link is safe', async () => {
-    setupDom();
+  const json = (obj) => new Response(JSON.stringify(obj), { headers:{'Content-Type':'application/json'} });
+
+  test('nėra [data-export-csv] → no-op (be throw)', async () => {
+    document.body.innerHTML = `<canvas data-equity></canvas>`;
+    global.fetch = jest.fn(() => Promise.resolve(json({ equity:[], links:{} })));
     const Analytics = await import('../../client/public/assets/analytics.js');
-    Analytics.initEquityChart({});
-    document.querySelector('[data-export-csv]').remove();
+    Analytics.init(document);
     expect(() => Analytics.updateCsvLink(document)).not.toThrow();
   });
 
-  test('no overlays leads to # and empty compose call', async () => {
-    setupDom();
+  test('tušti overlay ids → href "#"', async () => {
+    document.body.innerHTML = `<a data-export-csv href="#"></a><canvas data-equity></canvas>`;
+    global.fetch = jest.fn(() => Promise.resolve(json({ equity:[], links:{} })));
     const Analytics = await import('../../client/public/assets/analytics.js');
-    Analytics.initEquityChart({});
+    Analytics.init(document);
     Analytics.updateCsvLink(document);
-    expect(helpersMock.composeCsvUrl).toHaveBeenCalledWith([], { from_ms:'', to_ms:'' });
     expect(document.querySelector('[data-export-csv]').getAttribute('href')).toBe('#');
   });
 });
+

--- a/tests/unit/analytics.overlays.compose-params.test.js
+++ b/tests/unit/analytics.overlays.compose-params.test.js
@@ -1,0 +1,63 @@
+import 'whatwg-fetch';
+import 'jest-canvas-mock';
+import { jest } from '@jest/globals';
+
+const flush = () => new Promise(r=>setTimeout(r,0));
+const json = obj => new Response(JSON.stringify(obj), { status:200, headers:{'Content-Type':'application/json'} });
+
+async function mount(){
+  document.body.innerHTML = `
+    <section id="overlays-card">
+      <div data-overlays-list></div>
+      <a data-export-csv href="#"></a>
+      <fieldset>
+        <input name="symbol" value="SOL"/>
+        <input name="interval" value="1m"/>
+        <input name="from" value="1722470400000"/>
+        <input name="to" value="2024-08-31"/>
+        <select name="ds"><option value="none" selected>none</option><option value="lttb">lttb</option></select>
+        <input name="n" type="number" value=""/>
+        <button type="button" data-apply>Apply</button>
+        <button type="button" data-reset>Reset</button>
+      </fieldset>
+    </section>
+    <div id="toasts"></div>
+    <canvas data-equity></canvas>
+  `;
+  global.Chart = class { constructor(){ this.data={ datasets:[] }; this.update=jest.fn(); } };
+  global.fetch = jest.fn()
+    .mockResolvedValueOnce(json({ equity:[{ts:1,equity:100}], links:{} }))
+    .mockResolvedValueOnce(json([]))
+    .mockResolvedValue(json({ equity:[{ts:1,equity:101}], links:{} }));
+  const Analytics = await import('../../client/public/assets/analytics.js');
+  Analytics.init(document);
+  await flush();
+  return { fetchMock: global.fetch };
+}
+
+describe('overlays compose params branches', () => {
+  beforeEach(() => { jest.clearAllMocks(); jest.resetModules(); });
+
+  test('data-apply su ds=none ir n tuščias – siunčia tik ne-tuščius parametrus', async () => {
+    const { fetchMock } = await mount();
+    fetchMock.mockClear();
+    document.querySelector('[data-apply]').click();
+    await flush();
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('/analytics?baseline=live');
+    expect(url).toContain('ds=none');
+    expect(url).toContain('n=0');
+    expect(url).toMatch(/from_ms=1722470400000/);
+    expect(url).toMatch(/to_ms=2024-08-31/);
+  });
+
+  test('data-reset išvalo laukus į tuščias/default', async () => {
+    await mount();
+    document.querySelector('[data-reset]').click();
+    const from = document.querySelector('input[name="from"]');
+    const ds = document.querySelector('select[name="ds"]');
+    expect(from.value === '' || from.value === '1970-01-01').toBeTruthy();
+    expect(ds.value).toBe('lttb');
+  });
+});
+

--- a/tests/unit/analytics.overlays.topn-ui-events.test.js
+++ b/tests/unit/analytics.overlays.topn-ui-events.test.js
@@ -1,0 +1,156 @@
+import { jest } from '@jest/globals';
+
+function json(obj, status=200){ return new Response(JSON.stringify(obj), { status, headers:{'Content-Type':'application/json'} }); }
+function flush(){ return new Promise(r=>setTimeout(r,0)); }
+
+describe('analytics overlays ui events', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    document.body.innerHTML='';
+    delete global.fetch;
+    delete global.Toast;
+    delete navigator.clipboard;
+  });
+
+  test('queue topN backtest via UI', async () => {
+    global.Toast = { open: jest.fn(), close: jest.fn() };
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } };
+    const fetchMock = jest.fn(url => {
+      if (url.startsWith('/analytics/optimize/123/top')) return Promise.resolve(json({ top:[{ cagr:1, a:2 }] }));
+      if (url === '/jobs') return Promise.resolve(json({ id:5 }));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[] }));
+      return Promise.resolve(json({}));
+    });
+    global.fetch = fetchMock;
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
+    const root = document.createElement('div');
+    await mount(root);
+    root.querySelector('#ov-top-id').value = '123';
+    root.querySelector('#ov-top-load').click();
+    await flush();
+    const btn = root.querySelector('#ov-top-results button[data-idx="0"]');
+    btn.click();
+    await flush();
+    expect(fetchMock).toHaveBeenCalledWith('/jobs', expect.any(Object));
+  });
+
+  test('shareUrl error branch shows toast', async () => {
+    global.Toast = { open: jest.fn(), close: jest.fn() };
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } };
+    navigator.clipboard = { writeText: jest.fn() };
+    const fetchMock = jest.fn(url => {
+      if (url.startsWith('/analytics/overlay-sets')) return Promise.resolve(json({ sets:[] }));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[{id:1}] }));
+      if (url.startsWith('/analytics?overlay_job_ids=1')) return Promise.resolve(json({ overlayEquities:[{jobId:1,equity:[{ts:1,equity:1}]}], overlayStatsByJobId:{}, baseline:null }));
+      if (url === '/analytics/overlays/share') return Promise.reject(new Error('fail'));
+      return Promise.resolve(json({}));
+    });
+    global.fetch = fetchMock;
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
+    const root = document.createElement('div');
+    await mount(root);
+    root.querySelector('#ov-load').click();
+    await flush();
+    const cb = root.querySelector('#ov-jobs input[data-id="1"]');
+    cb.checked = true; cb.dispatchEvent(new Event('change'));
+    root.querySelector('#ov-share').click();
+    await flush();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Share failed', variant:'error' }));
+  });
+
+  test('loadTopN missing id warns and fetch error shows toast', async () => {
+    global.Toast = { open: jest.fn(), close: jest.fn() };
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } };
+    const fetchMock = jest.fn(url => {
+      if (url.startsWith('/analytics/overlay-sets')) return Promise.resolve(json({ sets:[] }));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[] }));
+      return Promise.reject(new Error('boom'));
+    });
+    global.fetch = fetchMock;
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
+    const root = document.createElement('div');
+    await mount(root);
+    root.querySelector('#ov-top-load').click();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Optimize job ID required', variant:'warning' }));
+    global.Toast.open.mockClear();
+    root.querySelector('#ov-top-id').value = '5';
+    root.querySelector('#ov-top-load').click();
+    await flush();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Load TOP-N failed', variant:'error' }));
+  });
+
+  test('loadTopNInline success and no items branches', async () => {
+    global.Toast = { open: jest.fn(), close: jest.fn() };
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } };
+    const fetchMock = jest.fn(url => {
+      if (url.startsWith('/analytics/overlay-sets')) return Promise.resolve(json({ sets:[] }));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[] }));
+      if (url.startsWith('/analytics/optimize/7/inline-overlays')) return Promise.resolve(json({ items:[{jobId:2,equity:[]}] }));
+      return Promise.resolve(json({}));
+    });
+    global.fetch = fetchMock;
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
+    const root = document.createElement('div');
+    await mount(root);
+    root.querySelector('#ov-top-id').value = '7';
+    root.querySelector('#ov-top-inline').click();
+    await flush();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ variant:'success' }));
+    // no items branch
+    fetchMock.mockImplementation(url => {
+      if (url.startsWith('/analytics/overlay-sets')) return Promise.resolve(json({ sets:[] }));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[] }));
+      if (url.startsWith('/analytics/optimize/8/inline-overlays')) return Promise.resolve(json({ items:[] }));
+      return Promise.resolve(json({}));
+    });
+    root.querySelector('#ov-top-id').value = '8';
+    root.querySelector('#ov-top-inline').click();
+    await flush();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'No inline overlays', variant:'warning' }));
+  });
+});
+
+
+  test('shareUrl success copies link', async () => {
+    global.Toast = { open: jest.fn(), close: jest.fn() };
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } };
+    navigator.clipboard = { writeText: jest.fn() };
+    const fetchMock = jest.fn(url => {
+      if (url.startsWith('/analytics/overlay-sets')) return Promise.resolve(json({ sets:[] }));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[{id:1}] }));
+      if (url.startsWith('/analytics?overlay_job_ids=1')) return Promise.resolve(json({ overlayEquities:[{jobId:1,equity:[{ts:1,equity:1}]}], overlayStatsByJobId:{}, baseline:null }));
+      if (url === '/analytics/overlays/share') return Promise.resolve(json({ url:'/x' }));
+      return Promise.resolve(json({}));
+    });
+    global.fetch = fetchMock;
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
+    const root = document.createElement('div'); await mount(root);
+    root.querySelector('#ov-load').click();
+    await flush();
+    const cb = root.querySelector('#ov-jobs input[data-id="1"]');
+    cb.checked = true; cb.dispatchEvent(new Event('change'));
+    root.querySelector('#ov-share').click();
+    await flush();
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'URL copied', variant:'success' }));
+  });
+
+  test('loadTopNInline fetch error shows toast', async () => {
+    global.Toast = { open: jest.fn(), close: jest.fn() };
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } };
+    const fetchMock = jest.fn(url => {
+      if (url.startsWith('/analytics/overlay-sets')) return Promise.resolve(json({ sets:[] }));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[] }));
+      if (url.startsWith('/analytics/optimize/9/inline-overlays')) return Promise.reject(new Error('bad'));
+      return Promise.resolve(json({}));
+    });
+    global.fetch = fetchMock;
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
+    const root = document.createElement('div'); await mount(root);
+    root.querySelector('#ov-top-id').value = '9';
+    root.querySelector('#ov-top-inline').click();
+    await flush();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Load inline failed', variant:'error' }));
+  });
+

--- a/tests/unit/analytics.overlays.ui-events.test.js
+++ b/tests/unit/analytics.overlays.ui-events.test.js
@@ -1,36 +1,41 @@
 import { jest } from '@jest/globals';
 
 function json(obj, status=200){ return new Response(JSON.stringify(obj), { status, headers:{'Content-Type':'application/json'} }); }
-function flush(){ return new Promise(r=>setTimeout(r,0)); }
+const flush = () => new Promise(r=>setTimeout(r,0));
 
-describe('analytics overlays ui events', () => {
+describe('analytics overlays ui-events', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
     document.body.innerHTML='';
-    delete global.fetch;
-    delete global.Toast;
   });
 
-  test('queue topN backtest via UI', async () => {
+  test('checkbox toggle and baseline stats branches', async () => {
     global.Toast = { open: jest.fn(), close: jest.fn() };
-    global.EventSource = class { constructor(){ this.close=jest.fn(); } };
-    const fetchMock = jest.fn(url => {
-      if (url.startsWith('/analytics/optimize/123/top')) return Promise.resolve(json({ top:[{ cagr:1, a:2 }] }));
-      if (url === '/jobs') return Promise.resolve(json({ id:5 }));
-      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[] }));
+    global.EventSource = class { constructor(){ this.close=jest.fn(); } addEventListener(){} };
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics/overlay-sets')) return Promise.resolve(json({ sets: [] }));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(json({ jobs:[{ id:1, type:'bt' }] }));
+      if (url.startsWith('/analytics?overlay_job_ids=1')) return Promise.resolve(json({ overlayEquities:[{ jobId:1, equity:[{ts:1,equity:1}] }], overlayStatsByJobId:{1:{return:0,maxDD:0}}, baseline:{ equity:[{ts:1,equity:100},{ts:2,equity:110}] } }));
       return Promise.resolve(json({}));
     });
-    global.fetch = fetchMock;
-    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
     const root = document.createElement('div');
+    const { mount } = await import('../../client/public/assets/modules/analytics/overlays.js');
     await mount(root);
-    root.querySelector('#ov-top-id').value = '123';
-    root.querySelector('#ov-top-load').click();
+    // load jobs
+    root.querySelector('#ov-load').click();
     await flush();
-    const btn = root.querySelector('#ov-top-results button[data-idx="0"]');
-    btn.click();
+    const cb = root.querySelector('#ov-jobs input[data-id="1"]');
+    cb.checked = true; cb.dispatchEvent(new Event('change'));
+    // apply overlays
+    root.querySelector('#ov-apply').click();
     await flush();
-    expect(fetchMock).toHaveBeenCalledWith('/jobs', expect.any(Object));
+    expect(root.querySelector('#ov-stats').textContent).toContain('ΔReturn vs Baseline');
+    // uncheck to remove and apply without selections
+    cb.checked = false; cb.dispatchEvent(new Event('change'));
+    root.querySelector('#ov-apply').click();
+    await flush();
+    expect(global.Toast.open).toHaveBeenCalledWith(expect.objectContaining({ title:'Select jobs first' }));
   });
 });
+

--- a/tests/unit/chart-globals.alt-branch.test.js
+++ b/tests/unit/chart-globals.alt-branch.test.js
@@ -1,0 +1,22 @@
+import { jest } from '@jest/globals';
+
+describe('chart-globals alt branch', () => {
+  test('import without global.Chart necrashina', async () => {
+    const saved = global.Chart;
+    // @ts-ignore
+    delete global.Chart;
+    await import('../../client/public/assets/chart-globals.js');
+    global.Chart = saved;
+  });
+
+  test('import with Chart.register necrashina', async () => {
+    const saved = global.Chart;
+    const reg = jest.fn();
+    // @ts-ignore
+    global.Chart = { register: reg };
+    await import('../../client/public/assets/chart-globals.js?x=2');
+    expect(reg).not.toHaveBeenCalled();
+    global.Chart = saved;
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for overlay UI events and parameter composition
- cover CSV link and chart globals fallback branches
- extend TOP-N overlay event scenarios

## Testing
- `npm run coverage:client:json`

------
https://chatgpt.com/codex/tasks/task_e_68b85c6e7a588325a1183aef61f09da8