### PR TITLE
feat: analytics dashboard v2.3 enhancements

### DIFF
--- a/client/public/analytics.html
+++ b/client/public/analytics.html
@@ -13,7 +13,7 @@
 <div id="app-breadcrumbs"></div>
 <div id="toasts"></div>
 <main class="container">
-  <fieldset class="filters">
+  <form id="filtersForm" class="filters">
     <label>Symbol <input name="symbol" list="symbols" value="SOLUSDT"></label>
     <datalist id="symbols"><option value="SOLUSDT"></option></datalist>
     <label>Interval
@@ -37,30 +37,32 @@
     <label>N <input name="n" type="number" value="1000"></label>
     <button type="button" data-apply>Apply</button>
     <button type="button" data-reset>Reset</button>
-  </fieldset>
+  </form>
 
-  <section class="card" id="equity-card">
+  <section class="card" id="equityCard">
     <h2>Equity (Baseline + Overlays)</h2>
-    <canvas data-equity></canvas>
+    <canvas id="equityChart" data-equity></canvas>
   </section>
 
-  <section class="card" id="overlays-card">
+  <section class="card" id="overlaysCard">
     <h2>Overlays</h2>
-    <div class="overlays-list" data-overlays-list></div>
-    <a data-export-csv href="#">Export Overlays CSV</a>
+    <div id="overlaysList" class="overlays-list" data-overlays-list></div>
+    <a id="csvExport" data-export-csv href="#">Export Overlays CSV</a>
   </section>
 
-  <section class="card" id="jobs-card">
+  <section class="card" id="jobsCard">
     <h2>Jobs</h2>
     <button type="button" data-jobs-refresh>Refresh</button>
-    <table data-jobs-table>
-      <thead><tr><th>id</th><th>type</th><th>symbol</th><th>strategy</th><th>status</th><th>artifacts</th></tr></thead>
+    <label><input type="checkbox" data-jobs-auto> Auto refresh</label>
+    <button type="button" data-backtest-quick>Backtest (quick)</button>
+    <table id="jobsTable" data-jobs-table>
+      <thead><tr><th>id</th><th>type</th><th>symbol</th><th>strategy</th><th>status</th><th>created</th><th>artifacts</th></tr></thead>
       <tbody></tbody>
     </table>
   </section>
 
-  <section class="card" id="stats-card">
-    <h2>Stats/Portfolio</h2>
+  <section class="card" id="portfolioCard">
+    <h2>Portfolio</h2>
     <div data-portfolio></div>
   </section>
 </main>

--- a/client/public/assets/analytics.css
+++ b/client/public/assets/analytics.css
@@ -1,3 +1,6 @@
 .filters{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin-bottom:16px}
 .card{border:1px solid #222;padding:16px;border-radius:8px;margin-bottom:16px;background:#111}
 .overlays-list div{margin:4px 0}
+table{width:100%;border-collapse:collapse}
+th,td{padding:4px;border:1px solid #333}
+table.mini th,table.mini td{font-size:12px;padding:2px 4px}

--- a/client/public/assets/analytics.js
+++ b/client/public/assets/analytics.js
@@ -15,36 +15,43 @@ if (ChartLib?.register && ChartLib.registerables) {
 const state = {
   chart: null,
   overlays: new Map(),
-  filters: {
+  filters: {},
+  timers: {},
+};
+
+function defaultFilters() {
+  return {
     symbol: 'SOLUSDT',
     interval: '1m',
     from_ms: '',
     to_ms: '',
-    strategy: '',
     ds: 'lttb',
     n: 1000,
-  },
-};
-
-export function persistFilters(store = localStorage) {
-  try { store.setItem('analyticsFilters', JSON.stringify(state.filters)); } catch {}
+  };
 }
 
-export function loadFilters(doc = document, store = localStorage) {
+export function loadFilters(store = localStorage) {
   try {
     const raw = store.getItem('analyticsFilters');
-    if (!raw) return;
-    const data = JSON.parse(raw);
-    Object.assign(state.filters, data);
-    doc.querySelector('[name=symbol]').value = state.filters.symbol || '';
-    doc.querySelector('[name=interval]').value = state.filters.interval || '';
-    doc.querySelector('[name=from]').value = state.filters.from_ms || '';
-    doc.querySelector('[name=to]').value = state.filters.to_ms || '';
-    const stratEl = doc.querySelector('[name=strategy]');
-    if (stratEl) stratEl.value = state.filters.strategy || '';
-    doc.querySelector('[name=ds]').value = state.filters.ds || '';
-    doc.querySelector('[name=n]').value = String(state.filters.n ?? '');
-  } catch {}
+    return raw ? { ...defaultFilters(), ...JSON.parse(raw) } : defaultFilters();
+  } catch {
+    return defaultFilters();
+  }
+}
+
+export function persistFilters(filters = state.filters, store = localStorage) {
+  try { store.setItem('analyticsFilters', JSON.stringify(filters)); } catch {}
+}
+
+function debounce(fn, ms) {
+  let t;
+  return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); };
+}
+
+function setLoading(key, val, doc = document) {
+  const ids = { equity: 'equityCard', jobs: 'jobsCard', portfolio: 'portfolioCard' };
+  const el = doc.getElementById(ids[key]);
+  if (el) el.classList.toggle('loading', val);
 }
 
 export function initEquityChart(ctx) {
@@ -89,15 +96,15 @@ export function setBaseline(points) {
 export function upsertOverlay(id, points, label) {
   state.overlays.set(String(id), points);
   const series = points.map(p => ({ x: p.ts, y: p.equity }));
-  const ds = { id: `overlay-${id}`, label, data: series, fill: false };
-  const i = state.chart.data.datasets.findIndex(d => d.id === `overlay-${id}`);
+  const ds = { id: `overlay:${id}`, label, data: series, fill: false };
+  const i = state.chart.data.datasets.findIndex(d => d.id === `overlay:${id}`);
   if (i >= 0) state.chart.data.datasets[i] = ds; else state.chart.data.datasets.push(ds);
   state.chart.update();
 }
 
 export function removeOverlay(id) {
   state.overlays.delete(String(id));
-  state.chart.data.datasets = state.chart.data.datasets.filter(d => d.id !== `overlay-${id}`);
+  state.chart.data.datasets = state.chart.data.datasets.filter(d => d.id !== `overlay:${id}`);
   state.chart.update();
 }
 
@@ -105,11 +112,23 @@ export function getChart() { return state.chart; }
 
 async function fetchJSON(url) {
   const r = await fetch(url);
-  if (!r.ok) throw new Error(`${url} [${r.status}]`);
+  if (!r.ok) {
+    let msg = '';
+    try { msg = (await r.json())?.message || ''; } catch {}
+    throw new Error(`${url} [${r.status}] ${msg}`.trim());
+  }
   return r.json();
 }
 
+let prefetchController;
+function prefetchEquity(id) {
+  if (prefetchController) prefetchController.abort();
+  prefetchController = new AbortController();
+  fetch(`/analytics/job/${id}/equity`, { signal: prefetchController.signal }).catch(() => {});
+}
+
 export async function fetchBaseline(doc = document) {
+  setLoading('equity', true, doc);
   try {
     const qs = composeAnalyticsQuery(state.filters);
     const url = `/analytics?baseline=live&${qs}`;
@@ -124,8 +143,11 @@ export async function fetchBaseline(doc = document) {
     if (eqLink) eqLink.href = links.equity || '#';
     if (trLink) trLink.href = links.trades || '#';
     updateCsvLink(doc);
+    await fetchPortfolio(doc);
   } catch (e) {
     showToast(`Failed to load baseline ${e.message || ''}`.trim(), { type: 'error', doc });
+  } finally {
+    setLoading('equity', false, doc);
   }
 }
 
@@ -142,12 +164,64 @@ export async function fetchOverlay(id, label, doc = document) {
 }
 
 export async function fetchJobs(doc = document) {
+  setLoading('jobs', true, doc);
   try {
     const data = await fetchJSON('/analytics/jobs?limit=20');
     renderJobsTable(data.jobs || data, doc);
     renderOverlayList(data.jobs || data, doc);
+    updateCsvLink(doc);
   } catch (e) {
     showToast(`Failed to load jobs ${e.message || ''}`.trim(), { type: 'error', doc });
+  } finally {
+    setLoading('jobs', false, doc);
+  }
+}
+
+export async function fetchPortfolio(doc = document) {
+  setLoading('portfolio', true, doc);
+  try {
+    const q = new URLSearchParams({ symbol: state.filters.symbol });
+    if (state.filters.from_ms) q.set('from_ms', state.filters.from_ms);
+    if (state.filters.to_ms) q.set('to_ms', state.filters.to_ms);
+    const data = await fetchJSON(`/portfolio?${q.toString()}`);
+    renderPortfolio(data, doc);
+  } catch (e) {
+    showToast(`Failed to load portfolio ${e.message || ''}`.trim(), { type: 'error', doc });
+  } finally {
+    setLoading('portfolio', false, doc);
+  }
+}
+
+function renderPortfolio(data, doc) {
+  const host = doc.querySelector('[data-portfolio]');
+  if (!host) return;
+  host.innerHTML = '';
+  if (Array.isArray(data?.holdings)) {
+    const table = doc.createElement('table');
+    table.className = 'mini';
+    table.innerHTML = '<thead><tr><th>asset</th><th>amount</th><th>value</th></tr></thead>';
+    const tbody = doc.createElement('tbody');
+    data.holdings.forEach(h => {
+      const tr = doc.createElement('tr');
+      tr.innerHTML = `<td>${h.asset || ''}</td><td>${h.amount || ''}</td><td>${h.value || ''}</td>`;
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    host.appendChild(table);
+  }
+  if (data?.allocation !== undefined) {
+    const p = doc.createElement('p');
+    p.textContent = `Allocation: ${data.allocation}`;
+    host.appendChild(p);
+  }
+  if (data?.risk) {
+    const ul = doc.createElement('ul');
+    Object.entries(data.risk).forEach(([k, v]) => {
+      const li = doc.createElement('li');
+      li.textContent = `${k}: ${v}`;
+      ul.appendChild(li);
+    });
+    host.appendChild(ul);
   }
 }
 
@@ -160,6 +234,7 @@ function renderOverlayList(list, doc) {
     const cb = doc.createElement('input');
     cb.type = 'checkbox';
     cb.dataset.jobId = job.id;
+    cb.checked = state.overlays.has(String(job.id));
     cb.addEventListener('change', () => handleOverlayToggle(job, doc));
     wrap.appendChild(cb);
     const label = doc.createElement('span');
@@ -175,15 +250,22 @@ function renderJobsTable(list, doc) {
   tbody.innerHTML = '';
   list.forEach(job => {
     const tr = doc.createElement('tr');
-    tr.innerHTML = `<td>${job.id}</td><td>${job.type || ''}</td><td>${job.symbol || ''}</td><td>${job.strategy || ''}</td><td>${job.status || ''}</td><td>${(job.artifacts||[]).map(a=>`<a href="${a.url}">${a.name||'dl'}</a>`).join(', ')}</td>`;
+    const created = job.created_at ? new Date(job.created_at).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' }) : '';
+    tr.innerHTML = `<td>${job.id}</td><td>${job.type || ''}</td><td>${job.symbol || ''}</td><td>${job.strategy || ''}</td><td>${job.status || ''}</td><td>${created}</td><td>${(job.artifacts||[]).map(a=>`<a href="${a.url}">${a.name||'dl'}</a>`).join(', ')}</td>`;
+    tr.addEventListener('mouseenter', () => prefetchEquity(job.id));
+    tr.addEventListener('mouseleave', () => prefetchController?.abort());
     tbody.appendChild(tr);
   });
+}
+
+export function getActiveOverlayIds(doc = document) {
+  return Array.from(doc.querySelectorAll('[data-overlays-list] input[type=checkbox]:checked')).map(cb => cb.dataset.jobId);
 }
 
 export function updateCsvLink(doc = document) {
   const link = doc.querySelector('[data-export-csv]');
   if (!link) return;
-  const ids = Array.from(state.overlays.keys());
+  const ids = getActiveOverlayIds(doc);
   link.href = composeCsvUrl(ids, { from_ms: state.filters.from_ms, to_ms: state.filters.to_ms });
 }
 
@@ -201,38 +283,85 @@ export function init(doc = document) {
   const canvas = doc.querySelector('[data-equity]');
   if (!canvas) return;
   state.chart = initEquityChart(canvas.getContext('2d'));
-  loadFilters(doc);
+  state.filters = loadFilters();
+  const form = doc.getElementById('filtersForm');
+  if (form) {
+    form.querySelector('[name=symbol]').value = state.filters.symbol;
+    form.querySelector('[name=interval]').value = state.filters.interval;
+    form.querySelector('[name=from]').value = state.filters.from_ms;
+    form.querySelector('[name=to]').value = state.filters.to_ms;
+    form.querySelector('[name=ds]').value = state.filters.ds;
+    form.querySelector('[name=n]').value = String(state.filters.n);
+    const persistDebounced = debounce(() => persistFilters(state.filters), 300);
+    form.addEventListener('change', () => {
+      state.filters = {
+        symbol: form.querySelector('[name=symbol]').value,
+        interval: form.querySelector('[name=interval]').value,
+        from_ms: form.querySelector('[name=from]').value,
+        to_ms: form.querySelector('[name=to]').value,
+        ds: form.querySelector('[name=ds]').value,
+        n: Number(form.querySelector('[name=n]').value),
+      };
+      persistDebounced();
+      updateCsvLink(doc);
+    });
+  }
   fetchBaseline(doc);
   fetchJobs(doc);
   const refreshBtn = doc.querySelector('[data-jobs-refresh]');
   if (refreshBtn) refreshBtn.addEventListener('click', () => fetchJobs(doc));
+  const autoChk = doc.querySelector('[data-jobs-auto]');
+  if (autoChk) autoChk.addEventListener('change', () => {
+    if (autoChk.checked) {
+      state.timers.jobs = setInterval(() => fetchJobs(doc), 30000);
+    } else {
+      clearInterval(state.timers.jobs); state.timers.jobs = null;
+    }
+  });
   const applyBtn = doc.querySelector('[data-apply]');
   if (applyBtn) applyBtn.addEventListener('click', () => {
-    state.filters = {
-      symbol: doc.querySelector('[name=symbol]').value,
-      interval: doc.querySelector('[name=interval]').value,
-      from_ms: doc.querySelector('[name=from]').value,
-      to_ms: doc.querySelector('[name=to]').value,
-      strategy: doc.querySelector('[name=strategy]')?.value || '',
-      ds: doc.querySelector('[name=ds]').value,
-      n: Number(doc.querySelector('[name=n]').value),
-    };
-    persistFilters();
+    if (form) {
+      state.filters = {
+        symbol: form.querySelector('[name=symbol]').value,
+        interval: form.querySelector('[name=interval]').value,
+        from_ms: form.querySelector('[name=from]').value,
+        to_ms: form.querySelector('[name=to]').value,
+        ds: form.querySelector('[name=ds]').value,
+        n: Number(form.querySelector('[name=n]').value),
+      };
+    }
+    persistFilters(state.filters);
     fetchBaseline(doc);
   });
   const resetBtn = doc.querySelector('[data-reset]');
   if (resetBtn) resetBtn.addEventListener('click', () => {
-    doc.querySelector('[name=symbol]').value = 'SOLUSDT';
-    doc.querySelector('[name=interval]').value = '1m';
-    doc.querySelector('[name=from]').value = '';
-    doc.querySelector('[name=to]').value = '';
-    const stratEl = doc.querySelector('[name=strategy]');
-    if (stratEl) stratEl.value = '';
-    doc.querySelector('[name=ds]').value = 'lttb';
-    doc.querySelector('[name=n]').value = '1000';
-    state.filters = { symbol:'SOLUSDT', interval:'1m', from_ms:'', to_ms:'', strategy:'', ds:'lttb', n:1000 };
-    persistFilters();
+    if (form) {
+      form.querySelector('[name=symbol]').value = 'SOLUSDT';
+      form.querySelector('[name=interval]').value = '1m';
+      form.querySelector('[name=from]').value = '';
+      form.querySelector('[name=to]').value = '';
+      form.querySelector('[name=ds]').value = 'lttb';
+      form.querySelector('[name=n]').value = '1000';
+    }
+    state.filters = defaultFilters();
+    persistFilters(state.filters);
+    updateCsvLink(doc);
     fetchBaseline(doc);
+  });
+  const btBtn = doc.querySelector('[data-backtest-quick]');
+  if (btBtn) btBtn.addEventListener('click', async () => {
+    try {
+      const body = { symbol: state.filters.symbol, interval: state.filters.interval, params: {} };
+      const r = await fetch('/jobs/backtest', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+      if (!r.ok) {
+        let msg = ''; try { msg = (await r.json())?.message || ''; } catch {}
+        throw new Error(`/jobs/backtest [${r.status}] ${msg}`.trim());
+      }
+      showToast('Backtest started', { doc });
+      fetchJobs(doc);
+    } catch (e) {
+      showToast(`Backtest failed ${e.message || ''}`.trim(), { type: 'error', doc });
+    }
   });
 }
 

--- a/tests/client/analytics.ui.ext.test.js
+++ b/tests/client/analytics.ui.ext.test.js
@@ -24,6 +24,7 @@ describe('analytics ui ext', () => {
     global.fetch = jest.fn(url => {
       if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
       if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('u');
     });
     jest.resetModules();
@@ -51,6 +52,7 @@ describe('analytics ui ext', () => {
     global.fetch = jest.fn(url => {
       if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
       if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('u');
     });
     jest.resetModules();
@@ -75,6 +77,7 @@ describe('analytics ui ext', () => {
     global.fetch = jest.fn(url => {
       if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
       if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('u');
     });
     jest.resetModules();
@@ -86,6 +89,8 @@ describe('analytics ui ext', () => {
     document.querySelector('[name=to]').value = '2';
     document.querySelector('[data-apply]').click();
     await flush();
+    const host = document.querySelector('[data-overlays-list]');
+    host.innerHTML = '<div><input type="checkbox" data-job-id="7" checked></div><div><input type="checkbox" data-job-id="8" checked></div>';
     mod.upsertOverlay('7', [{ ts:1, equity:2 }], 'A');
     mod.upsertOverlay('8', [{ ts:1, equity:3 }], 'B');
     mod.updateCsvLink(document);

--- a/tests/client/analytics.ui.test.js
+++ b/tests/client/analytics.ui.test.js
@@ -21,7 +21,10 @@ describe('analytics ui', () => {
   test('compose + apply builds query without empty strategy', async () => {
     setupDom();
     const baseline = { equity:[{ ts:1, equity:1 }], links:{} };
-    global.fetch = jest.fn(() => Promise.resolve(createJsonResponse(baseline)));
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
+      return Promise.resolve(createJsonResponse(baseline));
+    });
     jest.resetModules();
     const mod = await import('../../client/public/assets/analytics.js');
     mod.init(document);
@@ -46,6 +49,7 @@ describe('analytics ui', () => {
     global.fetch = jest.fn(url => {
       if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
       if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('unknown');
     });
     jest.resetModules();
@@ -64,7 +68,10 @@ describe('analytics ui', () => {
   test('reset clears filters', async () => {
     setupDom();
     const baseline = { equity:[], links:{} };
-    global.fetch = jest.fn(() => Promise.resolve(createJsonResponse(baseline)));
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
+      return Promise.resolve(createJsonResponse(baseline));
+    });
     jest.resetModules();
     const mod = await import('../../client/public/assets/analytics.js');
     mod.init(document);
@@ -88,6 +95,7 @@ describe('analytics ui', () => {
       if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
       if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse(jobs));
       if (url === '/analytics/job/7/equity') return Promise.resolve(createJsonResponse(overlay));
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('u');
     });
     jest.resetModules();
@@ -108,7 +116,10 @@ describe('analytics ui', () => {
 
   test('error 500 shows toast', async () => {
     setupDom();
-    global.fetch = jest.fn(() => Promise.resolve(new Response('',{ status:500 })));
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
+      return Promise.resolve(new Response('',{ status:500 }));
+    });
     jest.resetModules();
     const mod = await import('../../client/public/assets/analytics.js');
     mod.init(document);
@@ -122,6 +133,7 @@ describe('analytics ui', () => {
     global.fetch = jest.fn(url => {
       if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
       if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('u');
     });
     jest.resetModules();
@@ -139,6 +151,7 @@ describe('analytics ui', () => {
     global.fetch = jest.fn(url => {
       if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(bad));
       if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('u');
     });
     jest.resetModules();
@@ -156,6 +169,7 @@ describe('analytics ui', () => {
       if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
       if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse(jobs));
       if (url === '/analytics/job/5/equity') return Promise.resolve(new Response('',{ status:404 }));
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('u');
     });
     jest.resetModules();
@@ -179,6 +193,7 @@ describe('analytics ui', () => {
       if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
       if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse(jobs));
       if (url === '/analytics/job/7/equity') return Promise.resolve(createJsonResponse(overlay));
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('u');
     });
     jest.resetModules();

--- a/tests/unit/analytics.filters.persistence.test.js
+++ b/tests/unit/analytics.filters.persistence.test.js
@@ -14,12 +14,13 @@ describe('analytics filters persistence', () => {
   });
 
   test('loadFilters handles good, bad and missing data', () => {
-    document.body.innerHTML = '<input name="symbol"><input name="interval"><input name="from"><input name="to"><input name="strategy"><select name="ds"></select><input name="n">';
-    const goodStore = { getItem: () => JSON.stringify({ symbol:"SOL", interval:"1m", from_ms:"1", to_ms:"2", strategy:"ema", ds:"lttb", n:5 }) };
-    Analytics.loadFilters(document, goodStore);
+    const goodStore = { getItem: () => JSON.stringify({ symbol: 'SOL', n: 5 }) };
     const badStore = { getItem: () => 'bad json' };
-    expect(() => Analytics.loadFilters(document, badStore)).not.toThrow();
     const emptyStore = { getItem: () => null };
-    Analytics.loadFilters(document, emptyStore);
+    const good = Analytics.loadFilters(goodStore);
+    expect(good.symbol).toBe('SOL');
+    expect(() => Analytics.loadFilters(badStore)).not.toThrow();
+    const empty = Analytics.loadFilters(emptyStore);
+    expect(empty.symbol).toBe('SOLUSDT');
   });
 });

--- a/tests/unit/analytics.overlays.branch.test.js
+++ b/tests/unit/analytics.overlays.branch.test.js
@@ -45,6 +45,7 @@ describe('analytics overlays extra branches', () => {
       if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
       if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
       if (url === '/analytics/job/1/equity') return Promise.resolve(createJsonResponse(overlay));
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('unknown');
     });
     const mod = await import('../../client/public/assets/analytics.js');
@@ -56,10 +57,10 @@ describe('analytics overlays extra branches', () => {
     expect(chart.data.datasets.length).toBe(2);
     // duplicate overlay
     await mod.fetchOverlay(1, 'job-1', document);
-    expect(chart.data.datasets.filter(d=>d.id==='overlay-1').length).toBe(1);
+    expect(chart.data.datasets.filter(d=>d.id==='overlay:1').length).toBe(1);
     // remove
     mod.removeOverlay(1);
-    expect(chart.data.datasets.find(d=>d.id==='overlay-1')).toBeUndefined();
+    expect(chart.data.datasets.find(d=>d.id==='overlay:1')).toBeUndefined();
   });
 
   test('fetchOverlay errors and bad payload', async () => {
@@ -74,6 +75,7 @@ describe('analytics overlays extra branches', () => {
         calls++; if (calls===1) return Promise.resolve(new Response('',{status:404}));
         return Promise.resolve(createJsonResponse({ equity:null }));
       }
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('u');
     });
     const mod = await import('../../client/public/assets/analytics.js');
@@ -98,12 +100,15 @@ describe('analytics overlays extra branches', () => {
       if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
       if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
       if (url === '/analytics/job/3/equity') return Promise.resolve(createJsonResponse(overlay));
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('u');
     });
     const mod = await import('../../client/public/assets/analytics.js');
     mod.init(document);
     await flush();
     await mod.fetchOverlay(3, 'job-3', document);
+    const host = document.querySelector('[data-overlays-list]');
+    host.innerHTML = '<div><input type="checkbox" data-job-id="3" checked></div>';
     document.querySelector('[name=from]').value = '10';
     document.querySelector('[name=to]').value = '20';
     document.querySelector('[data-apply]').click();
@@ -120,6 +125,7 @@ describe('analytics overlays extra branches', () => {
     global.fetch = jest.fn(url => {
       if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
       if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
       return Promise.reject('u');
     });
     const mod = await import('../../client/public/assets/analytics.js');

--- a/tests/unit/analytics.overlays.compose-params.test.js
+++ b/tests/unit/analytics.overlays.compose-params.test.js
@@ -28,6 +28,7 @@ async function mount(){
   global.fetch = jest.fn()
     .mockResolvedValueOnce(json({ equity:[{ts:1,equity:100}], links:{} }))
     .mockResolvedValueOnce(json([]))
+    .mockResolvedValueOnce(json({}))
     .mockResolvedValue(json({ equity:[{ts:1,equity:101}], links:{} }));
   const Analytics = await import('../../client/public/assets/analytics.js');
   Analytics.init(document);

--- a/tests/unit/analytics.overlays.more-branches.test.js
+++ b/tests/unit/analytics.overlays.more-branches.test.js
@@ -69,6 +69,8 @@ describe('analytics overlays – extra branches', () => {
   test('update CSV with two overlays and full range sets correct href', () => {
     Analytics.upsertOverlay('a', [{ ts:1, equity:101 }], 'Overlay: a');
     Analytics.upsertOverlay('b', [{ ts:2, equity:102 }], 'Overlay: b');
+    const host = document.querySelector('[data-overlays-list]');
+    host.innerHTML = '<div><input type="checkbox" data-job-id="a" checked></div><div><input type="checkbox" data-job-id="b" checked></div>';
     Analytics.updateCsvLink(document);
     const expected = Helpers.composeCsvUrl(['a','b'], { from_ms:'', to_ms:'', ds:'lttb', n:1000 });
     expect(document.querySelector('[data-export-csv]').getAttribute('href')).toBe(expected);
@@ -78,6 +80,7 @@ describe('analytics overlays – extra branches', () => {
     const fetchMock = jest.fn()
       .mockResolvedValueOnce(json({ equity:[{ ts:1, equity:100 }], links:{} })) // baseline
       .mockResolvedValueOnce(json([])) // jobs
+      .mockResolvedValueOnce(json({})) // portfolio
       .mockResolvedValueOnce(new Response('x', { status:500 }))
       .mockResolvedValueOnce(new Response('x', { status:404 }))
       .mockResolvedValueOnce(json({ equity:null }))


### PR DESCRIPTION
## Summary
- persist analytics filters using localStorage and update UI components
- improve overlay handling and CSV export link generation
- add jobs auto-refresh, quick backtest, and portfolio summary card

## Testing
- `npm test` *(fails: ReferenceError: TextEncoder is not defined)*
- `npm run test:client:quick` *(fails: expected "" to be "A")*


------
https://chatgpt.com/codex/tasks/task_e_68b95569ffa0832582fa246b1e4b37f8