### PR TITLE
Analytics UI v2.4 — Dashboard polish (Overlays UX, Jobs, Portfolio, A11y)

### DIFF
--- a/client/public/analytics.html
+++ b/client/public/analytics.html
@@ -11,7 +11,7 @@
 <body data-page="Analytics">
 <div id="app-nav"></div>
 <div id="app-breadcrumbs"></div>
-<div id="toasts"></div>
+<div id="toasts" aria-live="polite"></div>
 <main class="container">
   <form id="filtersForm" class="filters">
     <label>Symbol <input name="symbol" list="symbols" value="SOLUSDT"></label>
@@ -40,14 +40,14 @@
   </form>
 
   <section class="card" id="equityCard">
-    <h2>Equity (Baseline + Overlays)</h2>
+    <h2 tabindex="-1">Equity (Baseline + Overlays)</h2>
     <canvas id="equityChart" data-equity></canvas>
   </section>
 
   <section class="card" id="overlaysCard">
     <h2>Overlays</h2>
     <div id="overlaysList" class="overlays-list" data-overlays-list></div>
-    <a id="csvExport" data-export-csv href="#">Export Overlays CSV</a>
+    <a id="csvExport" class="is-disabled" data-export-csv href="#">Export Overlays CSV</a>
   </section>
 
   <section class="card" id="jobsCard">

--- a/client/public/assets/analytics.css
+++ b/client/public/assets/analytics.css
@@ -1,6 +1,8 @@
 .filters{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin-bottom:16px}
 .card{border:1px solid #222;padding:16px;border-radius:8px;margin-bottom:16px;background:#111}
-.overlays-list div{margin:4px 0}
+.card.is-loading{opacity:.5;pointer-events:none}
+.overlays-list label{display:block;margin:4px 0}
+.is-disabled{opacity:.5;pointer-events:none}
 table{width:100%;border-collapse:collapse}
 th,td{padding:4px;border:1px solid #333}
 table.mini th,table.mini td{font-size:12px;padding:2px 4px}

--- a/client/public/assets/analytics.js
+++ b/client/public/assets/analytics.js
@@ -31,11 +31,13 @@ if (ChartLib?.register && ChartLib.registerables) {
     if (ds)    ds.value    = 'lttb';
     if (n)     n.value     = n.getAttribute('data-default') || '1000';
 
-    // Atnaujinti CSV nuorodą, jei turime helperį
+    // Atnaujinti CSV nuorodą ir fokusą
     if (typeof window.updateCsvLink === 'function') {
       const ids = (typeof window.getActiveOverlayIds === 'function') ? window.getActiveOverlayIds() : [];
       window.updateCsvLink(ids, { from_ms: '', to_ms: '' });
     }
+    const heading = document.querySelector('#equityCard h2');
+    if (heading) { heading.setAttribute('tabindex','-1'); heading.focus(); }
   });
 })();
 
@@ -78,7 +80,7 @@ function debounce(fn, ms) {
 function setLoading(key, val, doc = document) {
   const ids = { equity: 'equityCard', jobs: 'jobsCard', portfolio: 'portfolioCard' };
   const el = doc.getElementById(ids[key]);
-  if (el) el.classList.toggle('loading', val);
+  if (el) el.classList.toggle('is-loading', val);
 }
 
 export function initEquityChart(ctx) {
@@ -188,10 +190,10 @@ export async function fetchBaseline(doc = document) {
     const links = data.links || {};
     if (eqLink) eqLink.href = links.equity || '#';
     if (trLink) trLink.href = links.trades || '#';
-    updateCsvLink(doc);
+    updateCsvLink();
     await fetchPortfolio(doc);
   } catch (e) {
-    showToast(`Failed to load baseline ${e.message || ''}`.trim(), { type: 'error', doc });
+    showToast(e.message, { type: 'error', doc });
   } finally {
     setLoading('equity', false, doc);
   }
@@ -203,21 +205,21 @@ export async function fetchOverlay(id, label, doc = document) {
     const series = Array.isArray(data) ? normalizeEquity(data) : normalizeEquity(data?.equity);
     if (!series.length && !Array.isArray(data)) throw new Error('Bad equity data');
     upsertOverlay(id, series, label);
-    updateCsvLink(doc);
+    updateCsvLink();
   } catch (e) {
-    showToast(`Failed to load overlay ${e.message || ''}`.trim(), { type: 'error', doc });
+    showToast(e.message, { type: 'error', doc });
   }
 }
 
-export async function fetchJobs(doc = document) {
+export async function listJobs(doc = document) {
   setLoading('jobs', true, doc);
   try {
     const data = await fetchJSON('/analytics/jobs?limit=20');
     renderJobsTable(data.jobs || data, doc);
     renderOverlayList(data.jobs || data, doc);
-    updateCsvLink(doc);
+    updateCsvLink();
   } catch (e) {
-    showToast(`Failed to load jobs ${e.message || ''}`.trim(), { type: 'error', doc });
+    showToast(e.message, { type: 'error', doc });
   } finally {
     setLoading('jobs', false, doc);
   }
@@ -229,10 +231,20 @@ export async function fetchPortfolio(doc = document) {
     const q = new URLSearchParams({ symbol: state.filters.symbol });
     if (state.filters.from_ms) q.set('from_ms', state.filters.from_ms);
     if (state.filters.to_ms) q.set('to_ms', state.filters.to_ms);
-    const data = await fetchJSON(`/portfolio?${q.toString()}`);
-    renderPortfolio(data, doc);
+    const url = `/portfolio?${q.toString()}`;
+    const r = await fetch(url);
+    if (r.status === 204) {
+      renderPortfolio(null, doc);
+    } else if (r.ok) {
+      let data = null;
+      try { data = await r.json(); } catch {}
+      renderPortfolio(data, doc);
+    } else {
+      let msg = ''; try { msg = (await r.json())?.message || ''; } catch {}
+      throw new Error(`${url} [${r.status}] ${msg}`.trim());
+    }
   } catch (e) {
-    showToast(`Failed to load portfolio ${e.message || ''}`.trim(), { type: 'error', doc });
+    showToast(e.message, { type: 'error', doc });
   } finally {
     setLoading('portfolio', false, doc);
   }
@@ -242,7 +254,11 @@ function renderPortfolio(data, doc) {
   const host = doc.querySelector('[data-portfolio]');
   if (!host) return;
   host.innerHTML = '';
-  if (Array.isArray(data?.holdings)) {
+  if (!data || (!data.holdings && !data.allocation && !data.risk)) {
+    host.textContent = 'No portfolio data';
+    return;
+  }
+  if (Array.isArray(data.holdings) && data.holdings.length) {
     const table = doc.createElement('table');
     table.className = 'mini';
     table.innerHTML = '<thead><tr><th>asset</th><th>amount</th><th>value</th></tr></thead>';
@@ -255,19 +271,29 @@ function renderPortfolio(data, doc) {
     table.appendChild(tbody);
     host.appendChild(table);
   }
-  if (data?.allocation !== undefined) {
-    const p = doc.createElement('p');
-    p.textContent = `Allocation: ${data.allocation}`;
-    host.appendChild(p);
-  }
-  if (data?.risk) {
-    const ul = doc.createElement('ul');
-    Object.entries(data.risk).forEach(([k, v]) => {
-      const li = doc.createElement('li');
-      li.textContent = `${k}: ${v}`;
-      ul.appendChild(li);
+  if (data.allocation && typeof data.allocation === 'object' && Object.keys(data.allocation).length) {
+    const table = doc.createElement('table');
+    table.className = 'mini';
+    table.innerHTML = '<thead><tr><th>asset</th><th>%</th></tr></thead>';
+    const tbody = doc.createElement('tbody');
+    Object.entries(data.allocation).forEach(([asset, pct]) => {
+      const tr = doc.createElement('tr');
+      tr.innerHTML = `<td>${asset}</td><td>${pct}</td>`;
+      tbody.appendChild(tr);
     });
-    host.appendChild(ul);
+    table.appendChild(tbody);
+    host.appendChild(table);
+  }
+  if (data.risk && typeof data.risk === 'object') {
+    const ul = doc.createElement('ul');
+    ['maxDrawdown', 'vol', 'VaR'].forEach(k => {
+      if (data.risk[k] != null) {
+        const li = doc.createElement('li');
+        li.textContent = `${k}: ${data.risk[k]}`;
+        ul.appendChild(li);
+      }
+    });
+    if (ul.children.length) host.appendChild(ul);
   }
 }
 
@@ -276,17 +302,15 @@ function renderOverlayList(list, doc) {
   if (!host) return;
   host.innerHTML = '';
   list.forEach(job => {
-    const wrap = doc.createElement('div');
+    const label = doc.createElement('label');
     const cb = doc.createElement('input');
     cb.type = 'checkbox';
-    cb.dataset.jobId = job.id;
+    cb.dataset.overlayId = job.id;
     cb.checked = state.overlays.has(String(job.id));
     cb.addEventListener('change', () => handleOverlayToggle(job, doc));
-    wrap.appendChild(cb);
-    const label = doc.createElement('span');
-    label.textContent = overlayLabel(job);
-    wrap.appendChild(label);
-    host.appendChild(wrap);
+    label.appendChild(cb);
+    label.appendChild(doc.createTextNode(` ${overlayLabel(job)}`));
+    host.appendChild(label);
   });
 }
 
@@ -297,7 +321,11 @@ function renderJobsTable(list, doc) {
   list.forEach(job => {
     const tr = doc.createElement('tr');
     const created = job.created_at ? new Date(job.created_at).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' }) : '';
-    tr.innerHTML = `<td>${job.id}</td><td>${job.type || ''}</td><td>${job.symbol || ''}</td><td>${job.strategy || ''}</td><td>${job.status || ''}</td><td>${created}</td><td>${(job.artifacts||[]).map(a=>`<a href="${a.url}">${a.name||'dl'}</a>`).join(', ')}</td>`;
+    const arts = (job.artifacts || []).map(a => {
+      const name = a.name || (a.url ? a.url.split('/').pop() : 'file');
+      return `<a href="${a.url}" download>${name}</a>`;
+    }).join(', ');
+    tr.innerHTML = `<td>${job.id}</td><td>${job.type || ''}</td><td>${job.symbol || ''}</td><td>${job.strategy || ''}</td><td>${job.status || ''}</td><td>${created}</td><td>${arts}</td>`;
     tr.addEventListener('mouseenter', () => prefetchEquity(job.id));
     tr.addEventListener('mouseleave', () => prefetchController?.abort());
     tbody.appendChild(tr);
@@ -305,23 +333,26 @@ function renderJobsTable(list, doc) {
 }
 
 export function getActiveOverlayIds(doc = document) {
-  return Array.from(doc.querySelectorAll('[data-overlays-list] input[type=checkbox]:checked')).map(cb => cb.dataset.jobId);
+  const ids = [];
+  doc.querySelectorAll('[data-overlays-list] input[type=checkbox]:checked').forEach(cb => {
+    const id = cb.dataset.overlayId;
+    if (id && !ids.includes(id)) ids.push(id);
+  });
+  return ids;
 }
 
-export function updateCsvLink(idsOrDoc = document, range) {
-  if (Array.isArray(idsOrDoc)) {
-    const link = document.querySelector('[data-export-csv]');
-    if (!link) return;
-    const from = range?.from_ms ?? state.filters.from_ms;
-    const to = range?.to_ms ?? state.filters.to_ms;
-    link.href = composeCsvUrl(idsOrDoc, { from_ms: from, to_ms: to });
-    return;
-  }
-  const doc = idsOrDoc || document;
+export function updateCsvLink(ids, range, doc = document) {
+  const active = ids ?? getActiveOverlayIds(doc);
   const link = doc.querySelector('[data-export-csv]');
   if (!link) return;
-  const ids = getActiveOverlayIds(doc);
-  link.href = composeCsvUrl(ids, { from_ms: state.filters.from_ms, to_ms: state.filters.to_ms });
+  let from = range?.from_ms;
+  let to = range?.to_ms;
+  if (!range) {
+    from = doc.querySelector('input[name="from"]')?.value || '';
+    to = doc.querySelector('input[name="to"]')?.value || '';
+  }
+  link.href = composeCsvUrl(active, { from_ms: from, to_ms: to });
+  link.classList.toggle('is-disabled', active.length === 0);
 }
 
 if (typeof window !== 'undefined') {
@@ -331,11 +362,13 @@ if (typeof window !== 'undefined') {
 
 export async function handleOverlayToggle(job, doc = document) {
   const id = job.id ?? job;
+  const ids = getActiveOverlayIds(doc);
   if (state.overlays.has(String(id))) {
     removeOverlay(id);
-    updateCsvLink(doc);
+    updateCsvLink(ids);
     return;
   }
+  updateCsvLink(ids);
   await fetchOverlay(id, overlayLabel(job), doc);
 }
 
@@ -363,19 +396,25 @@ export function init(doc = document) {
         n: Number(form.querySelector('[name=n]').value),
       };
       persistDebounced();
-      updateCsvLink(doc);
+      updateCsvLink();
     });
   }
   fetchBaseline(doc);
-  fetchJobs(doc);
+  listJobs(doc);
   const refreshBtn = doc.querySelector('[data-jobs-refresh]');
-  if (refreshBtn) refreshBtn.addEventListener('click', () => fetchJobs(doc));
+  if (refreshBtn) refreshBtn.addEventListener('click', () => listJobs(doc));
   const autoChk = doc.querySelector('[data-jobs-auto]');
+  const startAuto = () => { state.timers.jobs = setInterval(() => listJobs(doc), 30000); };
+  const stopAuto = () => { clearInterval(state.timers.jobs); state.timers.jobs = null; };
   if (autoChk) autoChk.addEventListener('change', () => {
-    if (autoChk.checked) {
-      state.timers.jobs = setInterval(() => fetchJobs(doc), 30000);
+    if (autoChk.checked) startAuto(); else stopAuto();
+  });
+  doc.addEventListener('visibilitychange', () => {
+    if (doc.hidden) {
+      stopAuto();
     } else {
-      clearInterval(state.timers.jobs); state.timers.jobs = null;
+      listJobs(doc);
+      if (autoChk?.checked) startAuto();
     }
   });
   const applyBtn = doc.querySelector('[data-apply]');
@@ -390,6 +429,9 @@ export function init(doc = document) {
     };
     persistFilters(state.filters);
     fetchBaseline(doc);
+    updateCsvLink();
+    const heading = doc.querySelector('#equityCard h2');
+    if (heading) { heading.setAttribute('tabindex','-1'); heading.focus(); }
   });
   const btBtn = doc.querySelector('[data-backtest-quick]');
   if (btBtn) btBtn.addEventListener('click', async () => {
@@ -401,7 +443,7 @@ export function init(doc = document) {
         throw new Error(`/jobs/backtest [${r.status}] ${msg}`.trim());
       }
       showToast('Backtest started', { doc });
-      fetchJobs(doc);
+      listJobs(doc);
     } catch (e) {
       showToast(`Backtest failed ${e.message || ''}`.trim(), { type: 'error', doc });
     }

--- a/tests/client/analytics.ui.ext.test.js
+++ b/tests/client/analytics.ui.ext.test.js
@@ -90,10 +90,10 @@ describe('analytics ui ext', () => {
     document.querySelector('[data-apply]').click();
     await flush();
     const host = document.querySelector('[data-overlays-list]');
-    host.innerHTML = '<div><input type="checkbox" data-job-id="7" checked></div><div><input type="checkbox" data-job-id="8" checked></div>';
+    host.innerHTML = '<label><input type="checkbox" data-overlay-id="7" checked></label><label><input type="checkbox" data-overlay-id="8" checked></label>';
     mod.upsertOverlay('7', [{ ts:1, equity:2 }], 'A');
     mod.upsertOverlay('8', [{ ts:1, equity:3 }], 'B');
-    mod.updateCsvLink(document);
+    mod.updateCsvLink();
     const href = document.querySelector('[data-export-csv]').getAttribute('href');
     const expected = helpers.composeCsvUrl(['7','8'], { from_ms:'1', to_ms:'2' });
     expect(href).toBe(expected);

--- a/tests/client/analytics.ui.test.js
+++ b/tests/client/analytics.ui.test.js
@@ -108,10 +108,14 @@ describe('analytics ui', () => {
     const chart = mod.getChart();
     expect(chart.data.datasets.length).toBe(2);
     expect(chart.data.datasets[1].label).toBe('Overlay: 7');
+    expect(document.querySelector('[data-export-csv]').getAttribute('href')).toContain('ids=7');
+    expect(document.querySelector('[data-export-csv]').classList.contains('is-disabled')).toBe(false);
     cb.checked = false; cb.dispatchEvent(new Event('change'));
     await flush();
     expect(chart.data.datasets.length).toBe(1);
     expect(chart.data.datasets[0].label).toBe('Baseline');
+    expect(document.querySelector('[data-export-csv]').getAttribute('href')).toBe('#');
+    expect(document.querySelector('[data-export-csv]').classList.contains('is-disabled')).toBe(true);
   });
 
   test('error 500 shows toast', async () => {
@@ -124,7 +128,9 @@ describe('analytics ui', () => {
     const mod = await import('../../client/public/assets/analytics.js');
     mod.init(document);
     await flush();
-    expect(document.querySelector('.toast.error').textContent).toMatch(/Failed to load baseline/);
+    const msg = document.querySelector('.toast.error').textContent;
+    expect(msg).toContain('/analytics?baseline=live');
+    expect(msg).toContain('[500]');
   });
 
   test('empty data handled', async () => {
@@ -204,5 +210,56 @@ describe('analytics ui', () => {
     await mod.fetchOverlay(7, 'Overlay: 7', document);
     const chart = mod.getChart();
     expect(chart.data.datasets.filter(d=>d.id.startsWith('overlay')).length).toBe(1);
+  });
+
+  test('jobs auto-refresh stops hidden and resumes', async () => {
+    jest.useFakeTimers();
+    setupDom();
+    const baseline = { equity:[], links:{} };
+    let jobsCalls = 0;
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
+      if (url.startsWith('/analytics/jobs')) { jobsCalls++; return Promise.resolve(createJsonResponse([])); }
+      if (url.startsWith('/portfolio')) return Promise.resolve(createJsonResponse({}));
+      return Promise.reject('u');
+    });
+    jest.resetModules();
+    const mod = await import('../../client/public/assets/analytics.js');
+    mod.init(document);
+    await Promise.resolve();
+    const auto = document.querySelector('[data-jobs-auto]');
+    auto.checked = true; auto.dispatchEvent(new Event('change'));
+    jest.advanceTimersByTime(30000);
+    await Promise.resolve();
+    const beforeHide = jobsCalls;
+    Object.defineProperty(document, 'hidden', { configurable:true, value:true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    jest.advanceTimersByTime(60000);
+    await Promise.resolve();
+    expect(jobsCalls).toBe(beforeHide);
+    Object.defineProperty(document, 'hidden', { configurable:true, value:false });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await Promise.resolve();
+    const afterShow = jobsCalls;
+    jest.advanceTimersByTime(30000);
+    await Promise.resolve();
+    expect(jobsCalls).toBe(afterShow + 1);
+    jest.useRealTimers();
+  });
+
+  test('portfolio fallback when empty', async () => {
+    setupDom();
+    const baseline = { equity:[], links:{} };
+    global.fetch = jest.fn(url => {
+      if (url.startsWith('/analytics?baseline=live')) return Promise.resolve(createJsonResponse(baseline));
+      if (url.startsWith('/analytics/jobs')) return Promise.resolve(createJsonResponse([]));
+      if (url.startsWith('/portfolio')) return Promise.resolve(new Response('', { status:204 }));
+      return Promise.reject('u');
+    });
+    jest.resetModules();
+    const mod = await import('../../client/public/assets/analytics.js');
+    mod.init(document);
+    await flush();
+    expect(document.querySelector('[data-portfolio]').textContent).toBe('No portfolio data');
   });
 });

--- a/tests/client/analytics.updateCsvLink.fallback.test.js
+++ b/tests/client/analytics.updateCsvLink.fallback.test.js
@@ -16,16 +16,18 @@ describe('analytics.updateCsvLink fallback branches', () => {
     global.fetch = jest.fn(() => Promise.resolve(json({ equity:[], links:{} })));
     const Analytics = await import('../../client/public/assets/analytics.js');
     Analytics.init(document);
-    expect(() => Analytics.updateCsvLink(document)).not.toThrow();
+    expect(() => Analytics.updateCsvLink()).not.toThrow();
   });
 
-  test('tušti overlay ids → href "#"', async () => {
+  test('tušti overlay ids → href "#" ir .is-disabled', async () => {
     document.body.innerHTML = `<a data-export-csv href="#"></a><canvas data-equity></canvas>`;
     global.fetch = jest.fn(() => Promise.resolve(json({ equity:[], links:{} })));
     const Analytics = await import('../../client/public/assets/analytics.js');
     Analytics.init(document);
-    Analytics.updateCsvLink(document);
-    expect(document.querySelector('[data-export-csv]').getAttribute('href')).toBe('#');
+    Analytics.updateCsvLink([]);
+    const link = document.querySelector('[data-export-csv]');
+    expect(link.getAttribute('href')).toBe('#');
+    expect(link.classList.contains('is-disabled')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Improve overlay toggles and CSV export link with real-time sync and disabled state
- Add visibility-aware auto-refresh for jobs and better artifact links
- Render compact portfolio summary with graceful fallback and enhance accessibility

## Testing
- `npm run test:client -- tests/client/analytics.ui.test.js tests/client/analytics.ui.ext.test.js tests/client/analytics.updateCsvLink.fallback.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb5761c204832589c4235c0b2102f4