### PR TITLE
Add Aroon & Bollinger indicators with new pattern analysis

### DIFF
--- a/src/indicators/bollinger.js
+++ b/src/indicators/bollinger.js
@@ -1,0 +1,13 @@
+export function bollingerBands(values, period = 20, stdDev = 2) {
+  if (!Array.isArray(values) || values.length < period) return null;
+  const slice = values.slice(-period);
+  const mean = slice.reduce((a, b) => a + b, 0) / period;
+  const variance = slice.reduce((sum, v) => sum + Math.pow(v - mean, 2), 0) / period;
+  const sigma = Math.sqrt(variance);
+  return {
+    upper: mean + stdDev * sigma,
+    middle: mean,
+    lower: mean - stdDev * sigma
+  };
+}
+

--- a/src/signal/indicators/aroon.core.js
+++ b/src/signal/indicators/aroon.core.js
@@ -1,0 +1,7 @@
+import { aroon } from '../../indicators/aroon.js';
+
+export function computeAroon14(candles) {
+  const value = aroon(candles, 14);
+  return value == null ? null : value;
+}
+

--- a/src/signal/indicators/aroon.js
+++ b/src/signal/indicators/aroon.js
@@ -1,0 +1,7 @@
+import { timeIndicator } from '../instrumentation.js';
+import { computeAroon14 } from './aroon.core.js';
+
+export function aroonInstrumented({ candles, symbol, interval, strategy }) {
+  return timeIndicator({ indicator: 'aroon14', symbol, interval, strategy }, computeAroon14, candles);
+}
+

--- a/src/signal/indicators/bollinger.core.js
+++ b/src/signal/indicators/bollinger.core.js
@@ -1,0 +1,8 @@
+import { bollingerBands } from '../../indicators/bollinger.js';
+
+export function computeBollingerBands20(candles) {
+  const values = candles.map(c => c.close);
+  const value = bollingerBands(values, 20, 2);
+  return value == null ? null : value;
+}
+

--- a/src/signal/indicators/bollinger.js
+++ b/src/signal/indicators/bollinger.js
@@ -1,0 +1,7 @@
+import { timeIndicator } from '../instrumentation.js';
+import { computeBollingerBands20 } from './bollinger.core.js';
+
+export function bollingerBandsInstrumented({ candles, symbol, interval, strategy }) {
+  return timeIndicator({ indicator: 'bollinger20', symbol, interval, strategy }, computeBollingerBands20, candles);
+}
+

--- a/src/signal/indicators/patterns.core.js
+++ b/src/signal/indicators/patterns.core.js
@@ -1,8 +1,31 @@
-import { bullishEngulfing } from '../../indicators/patterns.js';
+import { bullishEngulfing, bearishEngulfing, doji } from '../../indicators/patterns.js';
 
 export function detectBullishEngulfing(candles) {
   if (!Array.isArray(candles) || candles.length < 2) return false;
   const [c1, c2] = candles.slice(-2);
   return bullishEngulfing(c1, c2);
+}
+
+export function detectBearishEngulfing(candles) {
+  if (!Array.isArray(candles) || candles.length < 2) return false;
+  const [c1, c2] = candles.slice(-2);
+  return bearishEngulfing(c1, c2);
+}
+
+export function detectDoji(candles) {
+  if (!Array.isArray(candles) || candles.length < 1) return false;
+  const [c] = candles.slice(-1);
+  return doji(c);
+}
+
+export function detectSupportResistance(candles) {
+  if (!Array.isArray(candles) || candles.length === 0) return null;
+  let support = Infinity;
+  let resistance = -Infinity;
+  for (const c of candles) {
+    if (c.low < support) support = c.low;
+    if (c.high > resistance) resistance = c.high;
+  }
+  return { support, resistance };
 }
 

--- a/src/signal/indicators/patterns.js
+++ b/src/signal/indicators/patterns.js
@@ -1,6 +1,19 @@
 import { timeIndicator } from '../instrumentation.js';
-import { detectBullishEngulfing } from './patterns.core.js';
+import { detectBullishEngulfing, detectBearishEngulfing, detectDoji, detectSupportResistance } from './patterns.core.js';
 
 export function bullishEngulfingInstrumented({ candles, symbol, interval, strategy }) {
   return timeIndicator({ indicator: 'bullish_engulfing', symbol, interval, strategy }, detectBullishEngulfing, candles);
 }
+
+export function bearishEngulfingInstrumented({ candles, symbol, interval, strategy }) {
+  return timeIndicator({ indicator: 'bearish_engulfing', symbol, interval, strategy }, detectBearishEngulfing, candles);
+}
+
+export function dojiInstrumented({ candles, symbol, interval, strategy }) {
+  return timeIndicator({ indicator: 'doji', symbol, interval, strategy }, detectDoji, candles);
+}
+
+export function supportResistanceInstrumented({ candles, symbol, interval, strategy }) {
+  return timeIndicator({ indicator: 'support_resistance', symbol, interval, strategy }, detectSupportResistance, candles);
+}
+

--- a/src/signal/instrumentation.js
+++ b/src/signal/instrumentation.js
@@ -9,7 +9,7 @@ import {
 } from '../metrics-signal.js';
 
 const NUMERIC_INDICATORS = new Set(['rsi14', 'atr14', 'ai_score', 'adx14', 'ema', 'sma']);
-const CATEGORICAL_INDICATORS = new Set(['trend', 'bullish_engulfing', 'bearish_engulfing', 'pattern']);
+const CATEGORICAL_INDICATORS = new Set(['trend', 'bullish_engulfing', 'bearish_engulfing', 'pattern', 'doji', 'support_resistance']);
 
 function isValidByType(indicator, raw) {
   if (raw == null) return false;


### PR DESCRIPTION
## Summary
- add Aroon and Bollinger Band indicator calculators with time instrumentation
- extend pattern analysis for bearish engulfing, doji, and support/resistance
- register new patterns for monitoring

## Testing
- `npm test 2>&1 | tail -n 20`
- `npm run lint >/tmp/lint.log && tail -n 20 /tmp/lint.log`


------
https://chatgpt.com/codex/tasks/task_e_68bb6f7cf7d08325a64ee32ea7f02cad