### PR TITLE
feat: support multi-strategy portfolio views

### DIFF
--- a/client/public/portfolio.html
+++ b/client/public/portfolio.html
@@ -18,6 +18,7 @@
         <button role="tab" id="tab-risk" data-tab="risk">Risk</button>
         <button role="tab" id="tab-corr" data-tab="corr">Correlation</button>
         <button role="tab" id="tab-attr" data-tab="attr">Attribution</button>
+        <button role="tab" id="tab-eq" data-tab="eq">Equity</button>
       </div>
 
       <section role="tabpanel" id="panel-alloc" data-tab-panel="alloc" aria-labelledby="tab-alloc"
@@ -33,6 +34,10 @@
 
       <section role="tabpanel" id="panel-attr" data-tab-panel="attr" aria-labelledby="tab-attr"
         data-lazy-module="/assets/modules/portfolio/attribution.js"
+        data-lazy-vendor="/assets/vendor/chart.umd.js" hidden></section>
+
+      <section role="tabpanel" id="panel-eq" data-tab-panel="eq" aria-labelledby="tab-eq"
+        data-lazy-module="/assets/modules/live/equity.js"
         data-lazy-vendor="/assets/vendor/chart.umd.js" hidden></section>
     </div>
   </main>

--- a/src/routes/analytics-overlay.js
+++ b/src/routes/analytics-overlay.js
@@ -5,8 +5,16 @@ import { db } from '../storage/db.js';
 
 const router = express.Router();
 
+function parseStrategies(q) {
+  const raw = q.strategy ?? q.strategies;
+  if (!raw) return [];
+  const arr = Array.isArray(raw) ? raw : String(raw).split(',');
+  return arr.map(s => s.trim()).filter(Boolean);
+}
+
 router.get('/analytics/overlay/:id', async (req, res) => {
   const jobId = Number(req.params.id);
+  const strategies = parseStrategies(req.query);
   const { rows: jrows } = await db.query('SELECT type FROM jobs WHERE id=$1', [jobId]);
   const jobType = jrows[0]?.type;
 
@@ -16,13 +24,15 @@ router.get('/analytics/overlay/:id', async (req, res) => {
 
   let equity = [];
   if (eqArt) {
-    const rows = await readArtifactCSV(jobId, eqArt.path);
+    let rows = await readArtifactCSV(jobId, eqArt.path);
+    if (strategies.length) rows = rows.filter(r => strategies.includes(String(r.strategy || '').trim()));
     equity = normalizeEquity(rows, jobType);
   }
 
   let trades = [];
   if (trArt) {
-    const rows = await readArtifactCSV(jobId, trArt.path);
+    let rows = await readArtifactCSV(jobId, trArt.path);
+    if (strategies.length) rows = rows.filter(r => strategies.includes(String(r.strategy || '').trim()));
     trades = normalizeTrades(rows);
   }
 

--- a/src/routes/analytics.overlays.csv.js
+++ b/src/routes/analytics.overlays.csv.js
@@ -4,6 +4,13 @@ import { db } from '../storage/db.js';
 
 const router = express.Router();
 
+function parseStrategies(q) {
+  const raw = q.strategy ?? q.strategies;
+  if (!raw) return [];
+  const arr = Array.isArray(raw) ? raw : String(raw).split(',');
+  return arr.map(s => s.trim()).filter(Boolean);
+}
+
 router.get('/analytics/overlays.csv', async (req, res) => {
   const ids = (req.query.job_ids || '')
     .split(',')
@@ -14,6 +21,7 @@ router.get('/analytics/overlays.csv', async (req, res) => {
     res.status(400).send('job_ids required');
     return;
   }
+  const strategies = parseStrategies(req.query);
 
   const series = [];
   const tsSet = new Set();
@@ -21,7 +29,8 @@ router.get('/analytics/overlays.csv', async (req, res) => {
     const arts = await listArtifacts(id);
     const a = arts.find(x => /equity\.csv$|oos_equity\.csv$/i.test(x.path));
     if (!a) continue;
-    const rows = await readArtifactCSV(id, a.path);
+    let rows = await readArtifactCSV(id, a.path);
+    if (strategies.length) rows = rows.filter(r => strategies.includes(String(r.strategy || '').trim()));
     const { rows: jrows } = await db.query('SELECT type FROM jobs WHERE id=$1', [id]);
     const eq = normalizeEquity(rows, jrows[0]?.type);
     series.push({ id, data: eq });

--- a/src/routes/portfolio.js
+++ b/src/routes/portfolio.js
@@ -11,10 +11,18 @@ function parseRangeMs(q) {
   return { fromMs, toMs };
 }
 
+function parseStrategies(q) {
+  const raw = q.strategy ?? q.strategies;
+  if (!raw) return [];
+  const arr = Array.isArray(raw) ? raw : String(raw).split(',');
+  return arr.map(s => s.trim()).filter(Boolean);
+}
+
 router.get('/portfolio', async (req, res) => {
   const range = parseRangeMs(req.query);
   if (!range) return res.status(400).json({ error: 'invalid_time_range' });
   const { fromMs, toMs } = range;
+  const strategies = parseStrategies(req.query);
 
   const openQ = await db.query(`
     SELECT symbol,
@@ -23,9 +31,10 @@ router.get('/portfolio', async (req, res) => {
            COUNT(*) FILTER (WHERE closed_at IS NULL) AS legs
     FROM paper_trades
     WHERE closed_at IS NULL
+      ${strategies.length ? 'AND strategy = ANY($1)' : ''}
     GROUP BY symbol
     HAVING ABS(COALESCE(SUM(CASE WHEN side='LONG' THEN qty ELSE -qty END),0)) > 0
-  `);
+  `, strategies.length ? [strategies] : []);
 
   const symbols = openQ.rows.map(r => r.symbol);
   const prices = await latestPrices(symbols);
@@ -56,28 +65,38 @@ router.get('/portfolio', async (req, res) => {
            SUM((CASE WHEN side='LONG' THEN 1 ELSE -1 END) * qty * (SELECT close FROM candles c WHERE c.symbol=pt.symbol ORDER BY ts DESC LIMIT 1)) AS signed_mv
     FROM paper_trades pt
     WHERE closed_at IS NULL
+      ${strategies.length ? 'AND strategy = ANY($1)' : ''}
     GROUP BY strategy
-  `);
+  `, strategies.length ? [strategies] : []);
   const totalStrat = stratQ.rows.reduce((s, r) => s + Math.abs(Number(r.signed_mv || 0)), 0) || 0;
   const allocByStrategy = stratQ.rows.map(r => ({
     strategy: r.strategy,
     weight: totalStrat ? Math.abs(Number(r.signed_mv || 0)) / totalStrat : 0
   })).sort((a, b) => b.weight - a.weight);
 
+  const symParams = [fromMs, toMs];
+  const symStratCond = strategies.length ? `AND strategy = ANY($${symParams.length + 1})` : '';
+  if (strategies.length) symParams.push(strategies);
   const attrSym = await db.query(`
     SELECT symbol, SUM(pnl) AS pnl
     FROM paper_trades
     WHERE closed_at IS NOT NULL AND closed_at BETWEEN $1::bigint AND $2::bigint
+      ${symStratCond}
     GROUP BY symbol
     ORDER BY SUM(pnl) DESC
-  `, [fromMs, toMs]);
+  `, symParams);
+
+  const strParams = [fromMs, toMs];
+  const strStratCond = strategies.length ? `AND strategy = ANY($${strParams.length + 1})` : '';
+  if (strategies.length) strParams.push(strategies);
   const attrStr = await db.query(`
     SELECT COALESCE(strategy,'default') AS strategy, SUM(pnl) AS pnl
     FROM paper_trades
     WHERE closed_at IS NOT NULL AND closed_at BETWEEN $1::bigint AND $2::bigint
+      ${strStratCond}
     GROUP BY strategy
     ORDER BY SUM(pnl) DESC
-  `, [fromMs, toMs]);
+  `, strParams);
 
   const retQ = await db.query(`
     WITH c AS (
@@ -173,13 +192,18 @@ router.get('/portfolio/attribution', async (req, res) => {
   const { fromMs, toMs } = range;
   const groupBy = (req.query.groupBy === 'strategy') ? 'strategy' : 'symbol';
   const col = groupBy === 'strategy' ? "COALESCE(strategy,'default')" : 'symbol';
+  const strategies = parseStrategies(req.query);
+  const params = [fromMs, toMs];
+  const stratCond = strategies.length ? `AND strategy = ANY($${params.length + 1})` : '';
+  if (strategies.length) params.push(strategies);
   const { rows } = await db.query(`
     SELECT ${col} AS key, SUM(pnl) AS pnl, COUNT(*) AS n
     FROM paper_trades
     WHERE closed_at IS NOT NULL AND closed_at BETWEEN $1::bigint AND $2::bigint
+      ${stratCond}
     GROUP BY ${col}
     ORDER BY SUM(pnl) DESC
-  `, [fromMs, toMs]);
+  `, params);
   res.json({ groupBy, items: rows });
 });
 

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -2,14 +2,33 @@ import ema from './ema.js';
 import adx from './adx.js';
 import rsi from './rsi.js';
 
-const strategies = [ema, adx, rsi].filter(Boolean);
+// Registry of available strategies
+const registry = new Map();
+
+function register(strat) {
+  if (strat?.id) registry.set(strat.id, strat);
+}
+
+// Register built-in strategies
+[ema, adx, rsi].forEach(register);
 
 export function getStrategies() {
-  return strategies;
+  return Array.from(registry.values());
 }
 
 export function getStrategyById(id) {
-  return strategies.find(s => s.id === id);
+  return registry.get(id);
 }
 
-export default { getStrategies, getStrategyById };
+export function createStrategy(cfg = {}) {
+  const strat = getStrategyById(cfg.id);
+  if (!strat) return null;
+  const params = { ...strat.defaultParams, ...(cfg.params || {}) };
+  return { ...strat, params };
+}
+
+export function createStrategies(list = []) {
+  return list.map(createStrategy).filter(Boolean);
+}
+
+export default { register, getStrategies, getStrategyById, createStrategy, createStrategies };


### PR DESCRIPTION
## Summary
- add strategy registry with create helpers
- allow filtering portfolio and analytics overlay routes by multiple strategies
- show live equity on portfolio page

## Testing
- `npm test` *(fails: document is not defined)*
- `npx eslint src/strategies/index.js src/routes/portfolio.js src/routes/analytics-overlay.js src/routes/analytics.overlays.csv.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbd24d45688325b2eb1c16451adf7c