### PR TITLE
Add Binance order execution and auto runner routes

### DIFF
--- a/src/liveRunner.js
+++ b/src/liveRunner.js
@@ -7,7 +7,7 @@ import binance from './integrations/binance/client.js';
 import { computeATR } from './risk/atr.js';
 import { computePositionSize } from './risk/sizing.js';
 import { loadExchangeFilters, roundPrice, ensureSymbolSettings } from './risk/limits.js';
-import { buildOrders } from './risk/orders.js';
+import { buildOrders, sendOrders } from './risk/orders.js';
 import { checkPreEntry } from './risk/guardrails.js';
 import { ensureDayStart, updateRealizedPnlToday } from './risk/state.js';
 import { noteSignal, noteSuppressed, noteMissingCandles, noteDataStaleness } from './signal/instrumentation.js';
@@ -144,11 +144,7 @@ export async function runOnce(liveConfig) {
               noteSignal({ strategy: strat.id, symbol, interval: cfg.interval, side });
               const orders = buildOrders({ side, entryType: 'MARKET', entryPrice, qty, sl, tp, symbol });
               try {
-                // entry first
-                await binance.send('POST', '/fapi/v1/order', orders[0], { signed: true });
-                // protective orders
-                await binance.send('POST', '/fapi/v1/order', orders[1], { signed: true });
-                await binance.send('POST', '/fapi/v1/order', orders[2], { signed: true });
+                await sendOrders(orders);
                 await openTrade(client, { ts: last.ts, side, price: entryPrice, strategyId: strat.id, params, symbol });
               } catch (e) {
                 console.error('Order error', e);
@@ -165,22 +161,51 @@ export async function runOnce(liveConfig) {
   }
 }
 
-let runnerState = { status: 'RUNNING', lastError: null };
+let runnerState = { status: 'STOPPED', lastError: null, lastRun: null };
 let activeConfig = null;
+let loopTimer = null;
+let pollMs = 60_000;
 
 export function getRunnerStatus() {
   return runnerState;
 }
 
-export async function gracefulRestart(newCfg) {
-  runnerState.status = 'RESTARTING';
+async function loop() {
+  if (runnerState.status !== 'RUNNING') return;
   try {
-    // Placeholder for stopping ongoing loops / timers
-    activeConfig = newCfg;
+    await runOnce(activeConfig);
+    runnerState.lastRun = Date.now();
+    runnerState.lastError = null;
   } catch (e) {
     runnerState.lastError = String(e);
-  } finally {
-    runnerState.status = 'RUNNING';
+  }
+  if (runnerState.status === 'RUNNING') {
+    loopTimer = setTimeout(loop, pollMs);
+  }
+}
+
+export function startRunner(cfg) {
+  activeConfig = cfg;
+  pollMs = Number(cfg?.pollMs || pollMs);
+  if (loopTimer) clearTimeout(loopTimer);
+  runnerState.status = 'RUNNING';
+  loop();
+}
+
+export function stopRunner() {
+  runnerState.status = 'STOPPED';
+  activeConfig = null;
+  if (loopTimer) {
+    clearTimeout(loopTimer);
+    loopTimer = null;
+  }
+}
+
+export async function gracefulRestart(newCfg) {
+  activeConfig = newCfg;
+  if (runnerState.status === 'RUNNING') {
+    if (loopTimer) clearTimeout(loopTimer);
+    loop();
   }
 }
 

--- a/src/risk/applyRisk.js
+++ b/src/risk/applyRisk.js
@@ -1,15 +1,62 @@
 import { noteRiskReject } from '../signal/instrumentation.js';
 
-export function applyRiskAndStops(order, ctx) {
-  const { strategy = 'default' } = ctx || {};
-  // ... tavo taisyklės
-  if (/* SL per platus */ false) {
-    noteRiskReject({ strategy, reason: 'sl_too_wide' });
-    return { ok: false, reason: 'sl_too_wide' };
+/**
+ * Basic risk application and stop evaluation.
+ *
+ * Evaluates whether a position should be closed based on TP/SL levels or
+ * trailing stop logic. Updates trailing stop top/bottom when price moves in
+ * favor of the position.
+ *
+ * @param {Object} position Position/order information
+ * @param {'BUY'|'SELL'} position.side      Entry side
+ * @param {number} position.entry          Entry price
+ * @param {number} [position.sl]           Stop loss price
+ * @param {number} [position.tp]           Take profit price
+ * @param {number} [position.trailPct]     Trailing stop percentage (0-1)
+ * @param {number} [position.trailTop]     Current trailing top/bottom
+ * @param {Object} ctx                      Context
+ * @param {number} ctx.price                Latest market price
+ * @param {string} [ctx.strategy='default'] Strategy identifier
+ * @returns {{ok:boolean, reason?:string, trailTop?:number}}
+ */
+export function applyRiskAndStops(position, ctx = {}) {
+  const { strategy = 'default', price } = ctx;
+  const { side, sl, tp, trailPct, trailTop } = position;
+
+  if (!Number.isFinite(price)) return { ok: true };
+
+  const oppHit = (lvl, cmp) => Number.isFinite(lvl) && cmp(lvl);
+
+  // Take profit check
+  if (oppHit(tp, lvl => (side === 'BUY' ? price >= lvl : price <= lvl))) {
+    noteRiskReject({ strategy, reason: 'tp_hit' });
+    return { ok: false, reason: 'tp_hit' };
   }
-  if (/* per daug atvirų */ false) {
-    noteRiskReject({ strategy, reason: 'max_open_trades' });
-    return { ok: false, reason: 'max_open_trades' };
+
+  // Stop loss check
+  if (oppHit(sl, lvl => (side === 'BUY' ? price <= lvl : price >= lvl))) {
+    noteRiskReject({ strategy, reason: 'sl_hit' });
+    return { ok: false, reason: 'sl_hit' };
   }
+
+  // Trailing stop logic
+  if (Number.isFinite(trailPct) && trailPct > 0) {
+    let top = trailTop ?? position.entry ?? price;
+    if (side === 'BUY') {
+      if (price > top) top = price; // move top
+      else if (price <= top * (1 - trailPct)) {
+        noteRiskReject({ strategy, reason: 'trail_hit' });
+        return { ok: false, reason: 'trail_hit', trailTop: top };
+      }
+    } else {
+      if (price < top) top = price;
+      else if (price >= top * (1 + trailPct)) {
+        noteRiskReject({ strategy, reason: 'trail_hit' });
+        return { ok: false, reason: 'trail_hit', trailTop: top };
+      }
+    }
+    return { ok: true, trailTop: top };
+  }
+
   return { ok: true };
 }

--- a/src/risk/orders.js
+++ b/src/risk/orders.js
@@ -12,6 +12,8 @@
  * @param {boolean} [p.reduceOnly=true] Whether protective orders should reduce only
  * @returns {Array<Object>} Array [entryOrder, slOrder, tpOrder]
  */
+import binance from '../integrations/binance/client.js';
+
 export function buildOrders(p) {
   const {
     side,
@@ -58,5 +60,21 @@ export function buildOrders(p) {
   return [entryOrder, slOrder, tpOrder];
 }
 
-export default { buildOrders };
+/**
+ * Send array of orders sequentially to Binance futures API.
+ *
+ * @param {Array<Object>} orders Array of order payloads
+ * @returns {Promise<Array<Object>>} array of responses
+ */
+export async function sendOrders(orders = []) {
+  const results = [];
+  for (const o of orders) {
+    // POST /fapi/v1/order with signed payload
+    const res = await binance.send('POST', '/fapi/v1/order', o, { signed: true });
+    results.push(res);
+  }
+  return results;
+}
+
+export default { buildOrders, sendOrders };
 

--- a/src/routes/auto.js
+++ b/src/routes/auto.js
@@ -1,0 +1,25 @@
+import express from 'express';
+import { startRunner, stopRunner, getRunnerStatus, getActiveRunnerConfig } from '../liveRunner.js';
+
+const router = express.Router();
+
+router.post('/auto/start', (req, res) => {
+  const cfg = req.body || {};
+  startRunner(cfg);
+  res.json({ ok: true, status: getRunnerStatus() });
+});
+
+router.post('/auto/stop', (_req, res) => {
+  stopRunner();
+  res.json({ ok: true, status: getRunnerStatus() });
+});
+
+router.get('/auto/status', (_req, res) => {
+  res.json({ status: getRunnerStatus(), config: getActiveRunnerConfig() });
+});
+
+export function autoRoutes(app) {
+  app.use(router);
+}
+
+export default { autoRoutes };

--- a/src/server.js
+++ b/src/server.js
@@ -17,6 +17,7 @@ import { portfolioRoutes } from './routes/portfolio.js';
 import { riskRoutes } from './routes/risk.js';
 import { getStrategies } from './strategies/index.js';
 import { configRoutes } from './routes/config.js';
+import { autoRoutes } from './routes/auto.js';
 import binanceRoutes from './integrations/binance/routes.js';
 import { healthRoutes } from './routes/health.js';
 import analyticsJobsRoutes from './routes/analytics.jobs.js';
@@ -93,6 +94,7 @@ userStreamRoutes(app);
 portfolioRoutes(app);
 riskRoutes(app);
 configRoutes(app);
+autoRoutes(app);
 jobRunner.start();
 
 app.post('/jobs/backtest', async (req, res) => {


### PR DESCRIPTION
## Summary
- add Binance futures order sending helper
- implement stop-loss/take-profit/trailing-stop checks
- introduce auto trading start/stop routes with status reporting

## Testing
- `npm test` *(fails: ReferenceError: document is not defined; Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd25dff24832587b53ed27128ebfb