### PR TITLE
Add security guidelines and secrets management

### DIFF
--- a/deploy/README-DEPLOY.md
+++ b/deploy/README-DEPLOY.md
@@ -27,6 +27,15 @@ cp deploy/.env.example /opt/crypto-signals/.env
 nano /opt/crypto-signals/.env   # fill Stripe/Telegram vars
 ```
 
+### Secrets management
+
+Instead of editing the `.env` file manually, fetch sensitive values from a secret manager:
+
+* **HashiCorp Vault** – use `vault kv get` during deployment or run a Vault Agent to template the file.
+* **Docker secrets** – create secrets with `docker secret create` and reference them from the compose file.
+
+Rotate credentials periodically and regenerate the `.env` or secrets before redeploying.
+
 ## 3) First run
 ```bash
 cd /opt/crypto-signals

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -25,14 +25,22 @@ kompose convert -f docker-compose.yml -o k8s/
 
 This generates deployment and service manifests under the `k8s/` directory. Review and customize the output.
 
-## 3. Configure Kubernetes Resources
+## 3. Secrets Management
+
+Use a dedicated secret store to supply runtime configuration:
+
+* For Kubernetes deployments create a Secret manifest such as `k8s/secret.example.yaml` and apply it with `kubectl apply -f` after populating the base64‑encoded values.
+* HashiCorp Vault can be used in place of static secrets. A Vault Agent sidecar may write secrets to a file or inject them as environment variables.
+* Rotate secrets regularly and update the running workloads by restarting pods or using a reloader operator.
+
+## 4. Configure Kubernetes Resources
 
 * Adjust resource requests/limits for each Deployment.
-* Configure environment variables and secrets (e.g., database credentials).
+* Mount or reference secrets via `envFrom` or `secretKeyRef`.
 * Add persistent volumes for stateful components like PostgreSQL.
 * Set up Ingress or LoadBalancer services to expose HTTP endpoints.
 
-## 4. Apply Manifests
+## 5. Apply Manifests
 
 ```bash
 kubectl apply -f k8s/
@@ -44,7 +52,7 @@ Monitor rollout status:
 kubectl get pods
 ```
 
-## 5. Database Migrations
+## 6. Database Migrations
 
 Run migrations inside the cluster using a Kubernetes Job:
 
@@ -67,11 +75,11 @@ spec:
 
 Apply the job and wait for completion before starting application pods.
 
-## 6. Observability
+## 7. Observability
 
 The repository includes example Prometheus, Alertmanager, and Grafana configs under `deploy/`. Deploy these into the cluster for metrics and alerting.
 
-## 7. CI/CD
+## 8. CI/CD
 
 Automate builds and deployments with your CI system. A typical workflow:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,25 @@
+# Security Guidelines
+
+This document outlines security practices for Crypto Signals, including TLS usage, secret rotation and incident response procedures.
+
+## Transport Layer Security (TLS)
+
+- **External traffic** must use HTTPS. Caddy is configured to obtain certificates automatically via Let's Encrypt.
+- **Internal services** should also encrypt traffic where possible. When deploying to Kubernetes, enable TLS for ingress controllers and any service-to-service communication.
+- Update certificates before expiration and monitor for failures in certificate renewal jobs.
+
+## Secret Management and Rotation
+
+- Store application secrets (API keys, database passwords, etc.) in a dedicated secret manager such as **HashiCorp Vault** or **Kubernetes Secrets**.
+- Avoid committing secrets to version control. Instead, inject them at runtime via environment variables or mounted files managed by the secret manager.
+- Rotate secrets on a regular schedule and immediately after any suspected compromise. Automation tools (e.g. Vault policies or Kubernetes secret updates) should propagate new values without downtime.
+
+## Incident Response
+
+1. **Detection** – use monitoring and alerting to detect anomalies or breaches.
+2. **Containment** – isolate affected components, revoke credentials and block suspicious traffic.
+3. **Eradication** – identify root cause and remove malicious artifacts. Apply patches or configuration fixes.
+4. **Recovery** – restore services using clean backups and reissue secrets/certificates.
+5. **Post‑mortem** – document the incident, lessons learned and follow‑up actions to prevent recurrence.
+
+Keep contact information for the security team up to date and rehearse the response plan regularly.

--- a/k8s/api.yaml
+++ b/k8s/api.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
         - name: api
           image: crypto-signals-api:latest
+          envFrom:
+            - secretRef:
+                name: api-secrets
           env:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://otel-collector:4318/v1/traces"

--- a/k8s/secret.example.yaml
+++ b/k8s/secret.example.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-secrets
+type: Opaque
+data:
+  STRIPE_SECRET: REPLACE_ME_BASE64
+  TELEGRAM_TOKEN: REPLACE_ME_BASE64
+  DATABASE_URL: REPLACE_ME_BASE64


### PR DESCRIPTION
## Summary
- document TLS requirements, secret rotation and incident response in `docs/security.md`
- describe using Kubernetes or Vault for secrets and reference example manifest
- load API secrets via Kubernetes `Secret` and note secret handling in deployment guide

## Testing
- `npm test` *(fails: Test Suites: 50 failed, 9 passed, 59 total)*
- `npm run lint` *(fails: 806 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe1f61630832593b307f88d1bd62a