### PR TITLE
docs: generate ER diagram and table descriptions

### DIFF
--- a/docs/er-diagram.md
+++ b/docs/er-diagram.md
@@ -3,13 +3,20 @@ erDiagram
   jobs {
     string id
     string type
+    string status
+    string priority
+    string created_at
     string queued_at
     string started_at
     string finished_at
     string progress
+    string params
+    string result
+    string error
   }
   equity_snapshots {
     string ts
+    string equity
     string source
     string created_at
   }
@@ -36,6 +43,7 @@ erDiagram
     string entry_price
     string unrealized_pnl
     string mode
+    string PRIMARY
   }
   strategy_configs {
     string id
@@ -54,15 +62,20 @@ erDiagram
     string id
     string trade_id
     string side
+    string price
     string qty
     string commission
+    string commission_asset
     string is_entry
+    string ts
   }
   job_artifacts {
     string id
     string job_id
     string kind
+    string label
     string path
+    string size_bytes
     string created_at
   }
   job_logs {
@@ -70,6 +83,7 @@ erDiagram
     string job_id
     string ts
     string level
+    string msg
   }
   risk_limits {
     string id
@@ -79,6 +93,7 @@ erDiagram
   risk_state {
     string id
     string state
+    string halt_reason
     string day_start
     string equity_day_start
     string equity_day_high
@@ -89,6 +104,7 @@ erDiagram
     string id
     string ts
     string action
+    string reason
     string details
   }
   equity_history {

--- a/docs/table-descriptions.md
+++ b/docs/table-descriptions.md
@@ -1,0 +1,130 @@
+# Database tables
+
+## jobs
+
+- id
+- type
+- status
+- priority
+- created_at
+- queued_at
+- started_at
+- finished_at
+- progress
+- params
+- result
+- error
+
+## equity_snapshots
+
+- ts
+- equity
+- source
+- created_at
+
+## overlay_sets
+
+- id
+- name
+- description
+- payload
+- pinned
+- token
+- created_at
+- updated_at
+
+## overlay_shares
+
+- id
+- token
+- payload
+- created_at
+
+## positions
+
+- ts
+- symbol
+- position_amt
+- entry_price
+- unrealized_pnl
+- mode
+- PRIMARY
+
+## strategy_configs
+
+- id
+- active
+- updated_at
+
+## strategy_presets
+
+- id
+- name
+- strategy_id
+- params
+- symbols
+- created_at
+
+## trade_fills
+
+- id
+- trade_id
+- side
+- price
+- qty
+- commission
+- commission_asset
+- is_entry
+- ts
+
+## job_artifacts
+
+- id
+- job_id
+- kind
+- label
+- path
+- size_bytes
+- created_at
+
+## job_logs
+
+- id
+- job_id
+- ts
+- level
+- msg
+
+## risk_limits
+
+- id
+- config
+- updated_at
+
+## risk_state
+
+- id
+- state
+- halt_reason
+- day_start
+- equity_day_start
+- equity_day_high
+- realized_pnl_today
+- updated_at
+
+## risk_halts
+
+- id
+- ts
+- action
+- reason
+- details
+
+## equity_history
+
+- ts
+- symbol
+- strategy
+- params
+- equity
+

--- a/tools/generate-erd.cjs
+++ b/tools/generate-erd.cjs
@@ -6,7 +6,7 @@ let match;
 while ((match = tableRegex.exec(sql))) {
   const name = match[1];
   const colsSection = match[2];
-  const lines = colsSection.split(/,\n/).map(l => l.trim()).filter(Boolean);
+  const lines = colsSection.split(/,\s*(?:--[^\n]*)?\r?\n/).map(l => l.trim()).filter(Boolean);
   tables[name] = { cols: [], refs: [] };
   for (const line of lines) {
     const colMatch = line.match(/^("?)(\w+)\1\s+/);
@@ -34,3 +34,13 @@ for (const [t, info] of Object.entries(tables)) {
   }
 }
 fs.writeFileSync('docs/er-diagram.md', '```mermaid\n' + out + '```\n');
+
+let doc = '# Database tables\n\n';
+for (const [t, info] of Object.entries(tables)) {
+  doc += `## ${t}\n\n`;
+  for (const c of info.cols) {
+    doc += `- ${c}\n`;
+  }
+  doc += '\n';
+}
+fs.writeFileSync('docs/table-descriptions.md', doc);


### PR DESCRIPTION
## Summary
- extend generate-erd script to parse schema and produce table docs
- regenerate ER diagram from migrations
- add table descriptions under docs

## Testing
- `npm test` *(fails: ReferenceError: document is not defined, missing @tensorflow/tfjs-node)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe202803c8325b656df23482aa776