### PR TITLE
feat: add real order routes and risk logging

### DIFF
--- a/src/risk/applyRisk.js
+++ b/src/risk/applyRisk.js
@@ -22,28 +22,30 @@ import { noteRiskReject } from '../signal/instrumentation.js';
 export function applyRiskAndStops(position, ctx = {}) {
   const { strategy = 'default', price } = ctx;
   const { side, sl, tp, trailPct, trailTop } = position;
-
   if (!Number.isFinite(price)) return { ok: true };
 
-  const oppHit = (lvl, cmp) => Number.isFinite(lvl) && cmp(lvl);
+  const isLong = side === 'BUY';
 
-  // Take profit check
-  if (oppHit(tp, lvl => (side === 'BUY' ? price >= lvl : price <= lvl))) {
-    noteRiskReject({ strategy, reason: 'tp_hit' });
-    return { ok: false, reason: 'tp_hit' };
+  if (Number.isFinite(tp)) {
+    const hit = isLong ? price >= tp : price <= tp;
+    if (hit) {
+      noteRiskReject({ strategy, reason: 'tp_hit' });
+      return { ok: false, reason: 'tp_hit' };
+    }
   }
 
-  // Stop loss check
-  if (oppHit(sl, lvl => (side === 'BUY' ? price <= lvl : price >= lvl))) {
-    noteRiskReject({ strategy, reason: 'sl_hit' });
-    return { ok: false, reason: 'sl_hit' };
+  if (Number.isFinite(sl)) {
+    const hit = isLong ? price <= sl : price >= sl;
+    if (hit) {
+      noteRiskReject({ strategy, reason: 'sl_hit' });
+      return { ok: false, reason: 'sl_hit' };
+    }
   }
 
-  // Trailing stop logic
   if (Number.isFinite(trailPct) && trailPct > 0) {
-    let top = trailTop ?? position.entry ?? price;
-    if (side === 'BUY') {
-      if (price > top) top = price; // move top
+    let top = Number.isFinite(trailTop) ? trailTop : (position.entry ?? price);
+    if (isLong) {
+      if (price > top) top = price;
       else if (price <= top * (1 - trailPct)) {
         noteRiskReject({ strategy, reason: 'trail_hit' });
         return { ok: false, reason: 'trail_hit', trailTop: top };

--- a/src/risk/orders.js
+++ b/src/risk/orders.js
@@ -13,6 +13,7 @@
  * @returns {Array<Object>} Array [entryOrder, slOrder, tpOrder]
  */
 import binance from '../integrations/binance/client.js';
+import { db } from '../storage/db.js';
 
 export function buildOrders(p) {
   const {
@@ -72,6 +73,25 @@ export async function sendOrders(orders = []) {
     // POST /fapi/v1/order with signed payload
     const res = await binance.send('POST', '/fapi/v1/order', o, { signed: true });
     results.push(res);
+    try {
+      await db.query(
+        `INSERT INTO orders (binance_order_id, client_order_id, symbol, side, type, price, stop_price, qty, status)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+        [
+          res.orderId || null,
+          res.clientOrderId || null,
+          res.symbol,
+          res.side,
+          res.type,
+          res.price ? Number(res.price) : null,
+          res.stopPrice ? Number(res.stopPrice) : null,
+          res.origQty ? Number(res.origQty) : null,
+          res.status || null,
+        ],
+      );
+    } catch {
+      // DB logging failures should not interrupt order placement
+    }
   }
   return results;
 }

--- a/src/routes/auto.js
+++ b/src/routes/auto.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { startRunner, stopRunner, getRunnerStatus, getActiveRunnerConfig } from '../liveRunner.js';
+import { buildOrders, sendOrders } from '../risk/orders.js';
 
 const router = express.Router();
 
@@ -16,6 +17,17 @@ router.post('/auto/stop', (_req, res) => {
 
 router.get('/auto/status', (_req, res) => {
   res.json({ status: getRunnerStatus(), config: getActiveRunnerConfig() });
+});
+
+router.post('/auto/order', async (req, res) => {
+  try {
+    const params = req.body || {};
+    const orders = buildOrders(params);
+    const result = await sendOrders(orders);
+    res.json({ ok: true, result });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: String(e) });
+  }
 });
 
 export function autoRoutes(app) {

--- a/src/storage/migrations/2025-08-orders.sql
+++ b/src/storage/migrations/2025-08-orders.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS orders (
+  id SERIAL PRIMARY KEY,
+  binance_order_id BIGINT,
+  client_order_id TEXT,
+  symbol TEXT NOT NULL,
+  side TEXT NOT NULL,
+  type TEXT NOT NULL,
+  price DOUBLE PRECISION,
+  stop_price DOUBLE PRECISION,
+  qty DOUBLE PRECISION,
+  status TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/test/risk/orders-exec.test.js
+++ b/test/risk/orders-exec.test.js
@@ -1,0 +1,32 @@
+import assert from 'assert';
+import { jest } from '@jest/globals';
+
+const sendMock = jest.fn(async (_m, _p, payload) => ({
+  orderId: Math.floor(Math.random() * 1e6),
+  clientOrderId: 'cid',
+  status: 'NEW',
+  ...payload,
+}));
+const dbMock = { query: jest.fn(async () => {}) };
+
+jest.unstable_mockModule('../../src/integrations/binance/client.js', () => ({ default: { send: sendMock } }));
+jest.unstable_mockModule('../../src/storage/db.js', () => ({ db: dbMock }));
+
+const { buildOrders, sendOrders } = await import('../../src/risk/orders.js');
+
+const orders = buildOrders({
+  side: 'BUY',
+  entryType: 'MARKET',
+  entryPrice: 100,
+  qty: 1,
+  sl: 95,
+  tp: 110,
+  symbol: 'BTCUSDT',
+});
+
+const res = await sendOrders(orders);
+assert.equal(sendMock.mock.calls.length, 3);
+assert.equal(dbMock.query.mock.calls.length, 3);
+assert.equal(res[0].symbol, 'BTCUSDT');
+
+console.log('orders-exec.test passed');


### PR DESCRIPTION
## Summary
- enable placing Binance orders via `/auto/order` route
- log placed orders to DB and add migration
- enhance risk handling with stop loss, take profit and trailing stop
- add unit test for order sending

## Testing
- `npm test` *(fails: ReferenceError: document is not defined)*
- `npm test tests/integration/with-pg.int.test.cjs` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe208b3ec8325aad0f085b3c2b173