### PR TITLE
Add subscription-based auth and Telegram VIP notifier

### DIFF
--- a/deploy/README-cloud-run.md
+++ b/deploy/README-cloud-run.md
@@ -1,0 +1,43 @@
+# Deploy to Google Cloud Run
+
+These steps describe how to deploy the Crypto Signals API to [Google Cloud Run](https://cloud.google.com/run).
+
+## Prerequisites
+- Google Cloud project with billing enabled
+- gcloud CLI installed and authenticated (`gcloud auth login`)
+- A Cloud SQL PostgreSQL instance (or external Postgres database) and connection string
+
+## 1. Build and push the container
+```bash
+gcloud builds submit --tag gcr.io/PROJECT_ID/crypto-signals
+```
+Replace `PROJECT_ID` with your GCP project identifier.
+
+## 2. Deploy to Cloud Run
+```bash
+gcloud run deploy crypto-signals \
+  --image gcr.io/PROJECT_ID/crypto-signals \
+  --platform managed \
+  --region REGION \
+  --allow-unauthenticated \
+  --set-env-vars "AUTH_SECRET=change-me,DATABASE_URL=postgres://...",
+    "TELEGRAM_BOT_TOKEN=...",\
+    "TELEGRAM_CHAT_ID=...",\
+    "TELEGRAM_VIP_CHAT_ID=..."
+```
+Replace `REGION` and environment variables with real values. Cloud Run will expose a public HTTPS URL after deployment.
+
+## 3. Configure database access
+If using Cloud SQL:
+1. Enable the Cloud SQL Admin API.
+2. Create a Cloud SQL instance and database.
+3. Set `DATABASE_URL` with credentials, or use Cloud SQL connections with a service account.
+
+## 4. Update the service
+When new code is pushed:
+```bash
+gcloud builds submit --tag gcr.io/PROJECT_ID/crypto-signals
+gcloud run deploy crypto-signals --image gcr.io/PROJECT_ID/crypto-signals --region REGION
+```
+The service will roll out the new revision automatically.
+

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import { db } from '../storage/db.js';
 
 const SECRET = process.env.AUTH_SECRET || '';
 
@@ -29,17 +30,35 @@ function verifyToken(token, secret = SECRET) {
   return payload;
 }
 
-export function auth(req, res, next) {
+export async function auth(req, res, next) {
   if (!SECRET) return res.status(500).json({ error: 'auth_disabled' });
   const header = req.headers['authorization'] || '';
   const match = header.match(/^Bearer (.+)$/);
   if (!match) return res.status(401).json({ error: 'unauthorized' });
+  let payload;
   try {
-    const payload = verifyToken(match[1]);
-    req.user = payload;
-    next();
+    payload = verifyToken(match[1]);
   } catch {
     return res.status(401).json({ error: 'unauthorized' });
+  }
+
+  const email = (payload.email || payload.sub || '').trim().toLowerCase();
+  if (!email) return res.status(403).json({ error: 'subscription_required' });
+
+  try {
+    const { rows } = await db.query(
+      `SELECT status FROM subscribers WHERE email=$1 ORDER BY id DESC LIMIT 1`,
+      [email]
+    );
+    const status = rows[0]?.status;
+    if (!['active', 'trialing'].includes(status)) {
+      return res.status(403).json({ error: 'subscription_inactive' });
+    }
+    req.user = payload;
+    next();
+  } catch (e) {
+    console.error('auth db error:', e);
+    return res.status(500).json({ error: 'auth_db_error' });
   }
 }
 

--- a/src/notify/telegram.js
+++ b/src/notify/telegram.js
@@ -44,9 +44,9 @@ export async function sendMessage(chatId, text, opts = {}) {
  *  - ts: number (ms)
  */
 export async function sendTradeAlert(type, payload = {}) {
-  const chatId = process.env.TELEGRAM_CHAT_ID;
+  const chatId = process.env.TELEGRAM_VIP_CHAT_ID || process.env.TELEGRAM_CHAT_ID;
   if (!chatId) {
-    console.warn('[TG] Missing TELEGRAM_CHAT_ID – alerts disabled');
+    console.warn('[TG] Missing TELEGRAM_VIP_CHAT_ID/TELEGRAM_CHAT_ID – alerts disabled');
     return { ok: false, error: 'no-chat' };
   }
 
@@ -96,6 +96,12 @@ export async function notifyPublic(text) {
 
 export async function notifyPrivate(text) {
   const chatId = process.env.TELEGRAM_PRIVATE_CHAT_ID;
+  if (!chatId) return;
+  await sendMessage(chatId, text, { parse_mode: 'Markdown' });
+}
+
+export async function notifyVip(text) {
+  const chatId = process.env.TELEGRAM_VIP_CHAT_ID;
   if (!chatId) return;
   await sendMessage(chatId, text, { parse_mode: 'Markdown' });
 }

--- a/tests/helpers/pgContainer.js
+++ b/tests/helpers/pgContainer.js
@@ -85,6 +85,18 @@ async function createMinimalSchema(client) {
     CREATE INDEX IF NOT EXISTS idx_equity_snapshots_ts ON equity_snapshots(ts);
     CREATE INDEX IF NOT EXISTS idx_equity_snapshots_source_ts ON equity_snapshots(source, ts);
   `);
+
+  // subscribers table for auth middleware
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS subscribers(
+      id SERIAL PRIMARY KEY,
+      email TEXT,
+      subscription_id TEXT,
+      status TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE INDEX IF NOT EXISTS idx_subs_email ON subscribers(email);
+  `);
 }
 
 async function seedBasic(client) {
@@ -112,6 +124,12 @@ async function seedBasic(client) {
     INSERT INTO equity_snapshots(ts,equity,source) VALUES
       (1000,1000,'live'),(2000,1040,'live'),(3000,1085,'live')
     ON CONFLICT (ts) DO UPDATE SET equity=EXCLUDED.equity;
+  `);
+
+  await client.query(`
+    INSERT INTO subscribers(email, status)
+    VALUES ('test', 'active')
+    ON CONFLICT DO NOTHING;
   `);
 }
 

--- a/tests/integration/artifacts.routes.test.js
+++ b/tests/integration/artifacts.routes.test.js
@@ -43,8 +43,11 @@ describe('Artifacts routes', () => {
     const data = Buffer.from('ts,value\n1,100\n2,110\n3,120\n');
     fs.writeFileSync(abs, data);
 
-    db.query.mockImplementation(async (sql, params) => {
+    db.query.mockImplementation(async (sql) => {
       const s = sql.toString();
+      if (s.includes('subscribers')) {
+        return { rows: [{ status: 'active' }] };
+      }
       if (s.includes('job_artifacts') && s.includes('WHERE job_id=$1 AND id=$2')) {
         return { rows: [{ id: 5, job_id: 1, label: 'equity.csv', path: rel, size_bytes: data.length, remote_url: null }] };
       }

--- a/tests/integration/auth.middleware.test.js
+++ b/tests/integration/auth.middleware.test.js
@@ -5,7 +5,7 @@ import crypto from 'crypto';
 const SECRET = 'testsecret';
 process.env.AUTH_SECRET = SECRET;
 
-const mockDb = { query: jest.fn().mockResolvedValue({ rows: [] }) };
+const mockDb = { query: jest.fn().mockResolvedValue({ rows: [{ status: 'active' }] }) };
 await jest.unstable_mockModule('../../src/storage/db.js', () => ({
   db: mockDb,
   getDbPool: () => mockDb,
@@ -55,6 +55,12 @@ describe('auth middleware', () => {
   test('allows authorized /live', async () => {
     const res = await request(app).get('/live').set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
+  });
+
+  test('denies inactive subscriber', async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [{ status: 'canceled' }] });
+    const res = await request(app).get('/live').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
   });
 
   test('protects /risk routes', async () => {

--- a/tests/integration/live.equity.test.js
+++ b/tests/integration/live.equity.test.js
@@ -28,16 +28,20 @@ describe('/live/equity API', () => {
   beforeEach(()=> { db.query.mockReset(); });
 
   test('GET /live/equity returns series', async () => {
-    db.query.mockResolvedValueOnce({ rows: [
-      { ts: 1000, equity: 100 }, { ts: 2000, equity: 110 }, { ts: 3000, equity: 105 }
-    ]});
+    db.query
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] })
+      .mockResolvedValueOnce({ rows: [
+        { ts: 1000, equity: 100 }, { ts: 2000, equity: 110 }, { ts: 3000, equity: 105 }
+      ]});
     const res = await request(app).get('/live/equity?from=0&to=9999999').set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     expect(res.body.items.length).toBe(3);
   });
 
   test('POST /live/equity/snapshot upserts', async () => {
-    db.query.mockResolvedValueOnce({ rows: [] });
+    db.query
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] })
+      .mockResolvedValueOnce({ rows: [] });
     const res = await request(app).post('/live/equity/snapshot').set('Authorization', `Bearer ${token}`).send({ ts: 1234, equity: 101.5 });
     expect(res.status).toBe(201);
     expect(db.query).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- require active or trialing subscription for protected routes in auth middleware
- support VIP trade alerts and add `notifyVip` helper for Telegram integration
- document deployment to Google Cloud Run

## Testing
- `npm test` *(fails: ReferenceError: document is not defined; Could not find a working container runtime strategy)*
- `npm test tests/integration/auth.middleware.test.js tests/integration/live.equity.test.js tests/integration/artifacts.routes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbe20eb8388325aa91893cfb772575