### PR TITLE
Add mocked integration tests for payments and signals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run test:cov
+      - run: npm run test:integration
       - run: npm run test:client
       - run: npm run test:cov:client
       - name: Upload coverage

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "cross-env TZ=UTC NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand",
     "test:watch": "cross-env TZ=UTC NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "test:cov": "cross-env TZ=UTC NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --coverage",
+    "test:integration": "cross-env TZ=UTC NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest tests/integration",
     "test:client": "cross-env TZ=UTC NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest -c jest.client.config.cjs",
     "test:cov:client": "cross-env TZ=UTC NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest -c jest.client.config.cjs --coverage",
     "test:client:quick": "cross-env TZ=UTC NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest -c jest.client.config.cjs --maxWorkers=50%",

--- a/tests/integration/binance.client.int.test.js
+++ b/tests/integration/binance.client.int.test.js
@@ -1,0 +1,26 @@
+import { jest } from '@jest/globals';
+
+const mockRequest = jest.fn();
+const mockGet = jest.fn().mockResolvedValue({ data: { serverTime: Date.now() } });
+
+await jest.unstable_mockModule('axios', () => ({
+  default: { create: () => ({ request: mockRequest, get: mockGet }) }
+}));
+
+const client = (await import('../../src/integrations/binance/client.js')).default;
+
+describe('Binance client', () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  test('retries on rate limit and succeeds', async () => {
+    mockRequest
+      .mockRejectedValueOnce({ response: { status: 429 } })
+      .mockResolvedValueOnce({ data: { ok: true } });
+
+    const res = await client.send('GET', '/api/test');
+    expect(res).toEqual({ ok: true });
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/integration/notify.telegram.int.test.js
+++ b/tests/integration/notify.telegram.int.test.js
@@ -1,0 +1,33 @@
+import { jest } from '@jest/globals';
+
+process.env.TELEGRAM_BOT_TOKEN = 'token';
+process.env.TELEGRAM_CHAT_ID = '123';
+
+const sendMessage = jest.fn().mockResolvedValue({});
+
+class MockBot {
+  constructor() {}
+  sendMessage = sendMessage;
+  createChatInviteLink = jest.fn().mockResolvedValue({ invite_link: 'link' });
+}
+
+await jest.unstable_mockModule('node-telegram-bot-api', () => ({
+  default: MockBot
+}));
+
+const { sendTradeAlert } = await import('../../src/notify/telegram.js');
+
+describe('Telegram notifications', () => {
+  beforeEach(() => {
+    sendMessage.mockClear();
+  });
+
+  test('sendTradeAlert formats and sends message', async () => {
+    await sendTradeAlert('OPEN', { symbol: 'BTCUSDT', size: 1, entryPrice: 10000, ts: 0 });
+    expect(sendMessage).toHaveBeenCalled();
+    const [chatId, text] = sendMessage.mock.calls[0];
+    expect(chatId).toBe('123');
+    expect(text).toContain('OPEN');
+    expect(text).toContain('BTCUSDT');
+  });
+});

--- a/tests/integration/payments.stripe.int.test.js
+++ b/tests/integration/payments.stripe.int.test.js
@@ -1,0 +1,63 @@
+import { jest } from '@jest/globals';
+
+process.env.STRIPE_SECRET_KEY = 'sk_test';
+process.env.STRIPE_PRICE_ID = 'price_123';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec_123';
+process.env.PUBLIC_URL = 'https://example.com';
+
+const mockCreate = jest.fn().mockResolvedValue({ id: 'sess_123', url: 'https://checkout/' });
+const mockRetrieve = jest.fn();
+const mockConstructEvent = jest.fn();
+
+const mockDb = { query: jest.fn().mockResolvedValue({}) };
+await jest.unstable_mockModule('../../src/storage/db.js', () => ({
+  db: mockDb,
+  getDbPool: () => mockDb,
+  isDbReady: () => true,
+  listen: async () => () => {},
+  endPool: async () => {}
+}));
+
+await jest.unstable_mockModule('stripe', () => ({
+  default: jest.fn().mockImplementation(() => ({
+    checkout: { sessions: { create: mockCreate, retrieve: mockRetrieve } },
+    webhooks: { constructEvent: mockConstructEvent }
+  }))
+}));
+
+const { createCheckoutSession, stripeWebhook } = await import('../../src/payments/stripe.js');
+const { db } = await import('../../src/storage/db.js');
+
+describe('Stripe payments', () => {
+  beforeEach(() => {
+    mockCreate.mockClear();
+    mockRetrieve.mockClear();
+    mockConstructEvent.mockClear();
+    db.query.mockClear();
+  });
+
+  test('createCheckoutSession forwards session info', async () => {
+    const res = { json: jest.fn() };
+    await createCheckoutSession({}, res);
+    expect(mockCreate).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ id: 'sess_123', url: 'https://checkout/' });
+  });
+
+  test('stripeWebhook stores subscriber', async () => {
+    mockConstructEvent.mockReturnValue({
+      type: 'checkout.session.completed',
+      data: { object: { id: 'sess_123' } }
+    });
+    mockRetrieve.mockResolvedValue({
+      subscription: 'sub_123',
+      customer_details: { email: 'user@example.com' }
+    });
+    const req = { headers: { 'stripe-signature': 'sig' }, body: 'raw-body' };
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+    await stripeWebhook(req, res);
+    expect(mockConstructEvent).toHaveBeenCalled();
+    expect(mockRetrieve).toHaveBeenCalledWith('sess_123', { expand: ['subscription', 'customer'] });
+    expect(db.query).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ received: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add Stripe checkout and webhook integration tests with mocked API and DB
- cover Telegram alert formatting via mocked bot
- verify Binance client retry logic with mocked axios
- wire integration tests into CI pipeline

## Testing
- `npm test tests/integration/binance.client.int.test.js tests/integration/notify.telegram.int.test.js tests/integration/payments.stripe.int.test.js`
- `npm run test:integration -- tests/integration/binance.client.int.test.js tests/integration/notify.telegram.int.test.js tests/integration/payments.stripe.int.test.js` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe21600a88325af884241d41d8905