### PR TITLE
Add Kubernetes manifests and HTTPS proxy docs

### DIFF
--- a/deploy/k8s/api.yaml
+++ b/deploy/k8s/api.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: crypto-signals-api:latest
+          envFrom:
+            - secretRef:
+                name: api-secrets
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector:4318/v1/traces"
+            - name: DEPLOY_ENV
+              value: production
+            - name: SERVICE_NAMESPACE
+              value: crypto-signals
+          volumeMounts:
+            - name: logs
+              mountPath: /app/logs
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: logs
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+spec:
+  selector:
+    app: api
+  ports:
+    - port: 80
+      targetPort: 3000

--- a/deploy/k8s/grafana.yaml
+++ b/deploy/k8s/grafana.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:10.0.0
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/grafana
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  selector:
+    app: grafana
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/deploy/k8s/loki.yaml
+++ b/deploy/k8s/loki.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+data:
+  loki-config.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 0
+    ingester:
+      lifecycler:
+        address: 0.0.0.0
+        ring:
+          kvstore:
+            store: inmemory
+          replication_factor: 1
+      chunk_idle_period: 1h
+      chunk_retain_period: 30s
+    schema_config:
+      configs:
+        - from: 2020-10-15
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: loki_index_
+            period: 24h
+    storage_config:
+      boltdb_shipper:
+        active_index_directory: /loki/index
+        shared_store: filesystem
+      filesystem:
+        directory: /loki/chunks
+    limits_config:
+      retention_period: 168h
+    compactor:
+      working_directory: /loki/compactor
+      shared_store: filesystem
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:2.9.0
+          args: ["-config.file=/etc/loki/config.yaml"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+              readOnly: true
+            - name: storage
+              mountPath: /loki
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+            items:
+              - key: loki-config.yaml
+                path: config.yaml
+        - name: storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+spec:
+  selector:
+    app: loki
+  ports:
+    - port: 3100
+      targetPort: 3100

--- a/deploy/k8s/otel-collector.yaml
+++ b/deploy/k8s/otel-collector.yaml
@@ -1,0 +1,161 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+data:
+  collector-config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+      filelog:
+        include:
+          - /var/log/app/*.jsonl
+        start_at: beginning
+    
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 256
+      batch: {}
+      attributes:
+        actions:
+          - action: delete
+            key: userEmail
+          - action: delete
+            key: token
+          - action: delete
+            key: authorization
+          - action: delete
+            key: cookie
+          - action: delete
+            key: sessionId
+      resource:
+        attributes:
+          - action: upsert
+            key: service.namespace
+            value: ${SERVICE_NAMESPACE}
+          - action: upsert
+            key: deployment.environment
+            value: ${DEPLOY_ENV}
+      tail_sampling:
+        decision_wait: 15s
+        policies:
+          - name: errors
+            type: status_code
+            status_code: ERROR
+            sample_rate: ${TRACE_SAMPLING_ERROR}
+          - name: important-routes
+            type: string_attribute
+            string_attribute:
+              key: http.target
+              values:
+                - /analytics/*
+                - /events*
+                - /live*
+                - /orders*
+            sample_rate: ${TRACE_SAMPLING_IMPORTANT}
+          - name: default
+            type: probabilistic
+            probabilistic:
+              sampling_percentage: ${TRACE_SAMPLING_DEFAULT}
+    
+    exporters:
+      otlphttp:
+        endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      prometheus:
+        endpoint: 0.0.0.0:8889
+      loki:
+        endpoint: ${LOKI_ENDPOINT}
+        tls:
+          insecure: true
+      # googlecloud and awscloudwatch exporters are available but disabled by default
+      googlecloud:
+        project: ${GOOGLE_PROJECT_ID}
+      awscloudwatch:
+        region: ${AWS_REGION}
+    
+    extensions:
+      health_check:
+    
+    service:
+      extensions: [health_check]
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8888
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch, attributes, resource, tail_sampling]
+          exporters: [${TRACES_EXPORTER}]
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, batch, attributes, resource]
+          exporters: [${METRICS_EXPORTER}]
+        logs:
+          receivers: [otlp, filelog]
+          processors: [memory_limiter, batch, attributes, resource]
+          exporters: [${LOGS_EXPORTER}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.99.0
+          args: ["--config=/conf/collector-config.yaml"]
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://tempo:4318"
+            - name: LOKI_ENDPOINT
+              value: "http://loki:3100/loki/api/v1/push"
+            - name: TRACES_EXPORTER
+              value: otlphttp
+            - name: LOGS_EXPORTER
+              value: loki
+            - name: METRICS_EXPORTER
+              value: prometheus
+            - name: DEPLOY_ENV
+              value: staging
+            - name: SERVICE_NAMESPACE
+              value: crypto-signals
+            - name: TRACE_SAMPLING_DEFAULT
+              value: "0.01"
+            - name: TRACE_SAMPLING_ERROR
+              value: "1.0"
+            - name: TRACE_SAMPLING_IMPORTANT
+              value: "0.2"
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+spec:
+  selector:
+    app: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+    - name: otlp-http
+      port: 4318
+    - name: metrics
+      port: 8888

--- a/deploy/k8s/postgres.yaml
+++ b/deploy/k8s/postgres.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15
+          env:
+            - name: POSTGRES_DB
+              value: crypto
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: db-secrets
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-secrets
+                  key: password
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  clusterIP: None
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/deploy/k8s/prometheus.yaml
+++ b/deploy/k8s/prometheus.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+      - job_name: "kubernetes"
+        static_configs:
+          - targets: ["api:80"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.45.0
+          args: ["--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus"]
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+            - name: data
+              mountPath: /prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - port: 9090
+      targetPort: 9090

--- a/deploy/k8s/secret.example.yaml
+++ b/deploy/k8s/secret.example.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-secrets
+type: Opaque
+data:
+  STRIPE_SECRET: REPLACE_ME_BASE64
+  TELEGRAM_TOKEN: REPLACE_ME_BASE64
+  DATABASE_URL: REPLACE_ME_BASE64
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-secrets
+type: Opaque
+data:
+  username: REPLACE_ME_BASE64
+  password: REPLACE_ME_BASE64

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -87,5 +87,49 @@ Automate builds and deployments with your CI system. A typical workflow:
 2. Push images to registry.
 3. Use `kubectl` or GitOps (e.g., ArgoCD) to update the cluster.
 
+## 9. HTTPS with Caddy or Nginx
+
+Terminate TLS in front of the API using a reverse proxy. Two common options are
+[Caddy](https://caddyserver.com/) and [Nginx](https://nginx.org/).
+
+### Caddy
+
+Create a `Caddyfile` similar to:
+
+```text
+{
+  email you@example.com
+}
+
+example.com {
+  encode gzip
+  reverse_proxy api:3000
+}
+```
+
+Caddy will automatically obtain and renew Let's Encrypt certificates.
+
+### Nginx
+
+Request a certificate with Certbot and configure Nginx to proxy traffic:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name example.com;
+    ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://api:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+Nginx serves encrypted traffic on port 443 while forwarding requests to the
+API service inside the cluster.
+
 ---
 For local testing, `docker-compose.yml` remains available to spin up the stack quickly.


### PR DESCRIPTION
## Summary
- add deploy/k8s manifests for API, Postgres, and observability stack (Prometheus, Grafana, Loki, OpenTelemetry collector)
- document HTTPS configuration using Caddy or Nginx

## Testing
- `npm test tests/unit/analytics.helpers.test.js` *(fails: ReferenceError: document is not defined)*
- `npm test tests/integration/jobs.mvp.test.cjs` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe479038483259f2ae33f3ec347b9