### PR TITLE
fix: use glibc-compatible node base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # deps layer
-FROM node:20-alpine AS deps
+FROM node:20 AS deps
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev
 
 # runtime
-FROM node:20-alpine
+FROM node:20
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=deps /app/node_modules ./node_modules


### PR DESCRIPTION
## Summary
- use Debian-based Node 20 images to include glibc required by tfjs-node

## Testing
- `npm test` *(fails: ReferenceError: document is not defined)*
- `npm run lint` *(fails: 819 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bca11f2eb88325baddca1467d62248