### PR TITLE
Add comprehensive tests for auth middleware

### DIFF
--- a/tests/integration/auth.middleware.test.js
+++ b/tests/integration/auth.middleware.test.js
@@ -50,6 +50,7 @@ describe('auth middleware', () => {
   test('denies anonymous /live', async () => {
     const res = await request(app).get('/live');
     expect(res.status).toBe(401);
+    expect(res.body.error).toBe('unauthorized');
   });
 
   test('allows authorized /live', async () => {
@@ -61,6 +62,7 @@ describe('auth middleware', () => {
     mockDb.query.mockResolvedValueOnce({ rows: [{ status: 'canceled' }] });
     const res = await request(app).get('/live').set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(403);
+    expect(res.body.error).toBe('subscription_inactive');
   });
 
   test('protects /risk routes', async () => {
@@ -73,7 +75,37 @@ describe('auth middleware', () => {
   test('protects /jobs routes', async () => {
     let res = await request(app).get('/jobs');
     expect(res.status).toBe(401);
+    expect(res.body.error).toBe('unauthorized');
     res = await request(app).get('/jobs').set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
+  });
+
+  test('rejects invalid token', async () => {
+    const res = await request(app)
+      .get('/live')
+      .set('Authorization', 'Bearer invalid');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('unauthorized');
+  });
+
+  test('rejects expired token', async () => {
+    const expired = sign({ sub: 'tester', exp: Math.floor(Date.now() / 1000) - 10 });
+    const res = await request(app).get('/live').set('Authorization', `Bearer ${expired}`);
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('unauthorized');
+  });
+
+  test('requires email or sub', async () => {
+    const noEmail = sign({ exp: Math.floor(Date.now() / 1000) + 3600 });
+    const res = await request(app).get('/live').set('Authorization', `Bearer ${noEmail}`);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('subscription_required');
+  });
+
+  test('handles db errors', async () => {
+    mockDb.query.mockRejectedValueOnce(new Error('db fail'));
+    const res = await request(app).get('/live').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('auth_db_error');
   });
 });


### PR DESCRIPTION
## Summary
- expand auth middleware integration tests to cover invalid and expired tokens, missing subscriber emails, and database failures
- assert proper error responses for anonymous, inactive, and unauthorized access

## Testing
- `npm test tests/integration/auth.middleware.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bcb0a5f8a88325b407d889cda84f93