### PR TITLE
chore: remove unnecessary esm option

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,6 @@ export default {
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
   testTimeout: 15000,
-  extensionsToTreatAsEsm: ['.js'],
   collectCoverageFrom: [
     'src/**/*.js',
     '!src/**/server.js',


### PR DESCRIPTION
## Summary
- remove explicit `extensionsToTreatAsEsm` setting from Jest config

## Testing
- `npm test tests/integration/auth.middleware.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bd69e36dc4832599bf43df64a2b71c