### PR TITLE
Add comprehensive auth middleware tests and curl script

### DIFF
--- a/scripts/auth-test.sh
+++ b/scripts/auth-test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_URL="${API_URL:-http://localhost:3000}"
+EMAIL="${AUTH_EMAIL:-test@example.com}"
+SECRET="${AUTH_SECRET:-}"
+
+if [[ -z "$SECRET" ]]; then
+  echo "AUTH_SECRET is required" >&2
+  exit 1
+fi
+
+TOKEN=$(node - "$EMAIL" "$SECRET" <<'NODE'
+const [email, secret] = process.argv.slice(1);
+const crypto = require('crypto');
+function b64url(input){ return Buffer.from(input).toString('base64url'); }
+const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+const payload = b64url(JSON.stringify({ email, exp: Math.floor(Date.now()/1000)+60 }));
+const sig = crypto.createHmac('sha256', secret).update(`${header}.${payload}`).digest('base64url');
+console.log(`${header}.${payload}.${sig}`);
+NODE
+)
+
+echo "==> Request without token (expect 401)"
+curl -s -w '\nHTTP %{http_code}\n' "$API_URL/live"
+
+echo "==> Request with invalid token (expect 401)"
+curl -s -w '\nHTTP %{http_code}\n' -H "Authorization: Bearer invalid" "$API_URL/live"
+
+echo "==> Request with valid token (expect 200 if subscriber active)"
+curl -s -w '\nHTTP %{http_code}\n' -H "Authorization: Bearer $TOKEN" "$API_URL/live"

--- a/tests/integration/auth.middleware.test.js
+++ b/tests/integration/auth.middleware.test.js
@@ -50,6 +50,7 @@ describe('auth middleware', () => {
   test('denies anonymous /live', async () => {
     const res = await request(app).get('/live');
     expect(res.status).toBe(401);
+    expect(res.body.error).toBe('unauthorized');
   });
 
   test('allows authorized /live', async () => {
@@ -61,6 +62,7 @@ describe('auth middleware', () => {
     mockDb.query.mockResolvedValueOnce({ rows: [{ status: 'canceled' }] });
     const res = await request(app).get('/live').set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(403);
+    expect(res.body.error).toBe('subscription_inactive');
   });
 
   test('protects /risk routes', async () => {
@@ -73,7 +75,37 @@ describe('auth middleware', () => {
   test('protects /jobs routes', async () => {
     let res = await request(app).get('/jobs');
     expect(res.status).toBe(401);
+    expect(res.body.error).toBe('unauthorized');
     res = await request(app).get('/jobs').set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
+  });
+
+  test('rejects invalid token', async () => {
+    const res = await request(app)
+      .get('/live')
+      .set('Authorization', 'Bearer invalid');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('unauthorized');
+  });
+
+  test('rejects expired token', async () => {
+    const expired = sign({ sub: 'tester', exp: Math.floor(Date.now() / 1000) - 10 });
+    const res = await request(app).get('/live').set('Authorization', `Bearer ${expired}`);
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('unauthorized');
+  });
+
+  test('requires email or sub', async () => {
+    const noEmail = sign({ exp: Math.floor(Date.now() / 1000) + 3600 });
+    const res = await request(app).get('/live').set('Authorization', `Bearer ${noEmail}`);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('subscription_required');
+  });
+
+  test('handles db errors', async () => {
+    mockDb.query.mockRejectedValueOnce(new Error('db fail'));
+    const res = await request(app).get('/live').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('auth_db_error');
   });
 });


### PR DESCRIPTION
## Summary
- expand auth middleware integration tests to cover invalid and expired tokens, missing subscriber emails, and database failures
- add `scripts/auth-test.sh` for quick curl-based checks against `/live`

## Testing
- `npm test tests/integration/auth.middleware.test.js`
- `bash -n scripts/auth-test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bcb0a5f8a88325b407d889cda84f93