### PR TITLE
feat: add frontend auth token support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ coverage/
 
 # Build output
 public/
+!client/public/
+!client/public/**
 
 # Playwright cache/artifacts
 playwright/

--- a/client/public/assets/auth.js
+++ b/client/public/assets/auth.js
@@ -1,0 +1,47 @@
+/* eslint-env browser */
+let token;
+
+if (typeof window !== 'undefined') {
+  token = localStorage.getItem('auth_token');
+  const params = new URLSearchParams(window.location.search);
+  const urlToken = params.get('token');
+  if (urlToken) {
+    token = urlToken;
+    try { localStorage.setItem('auth_token', token); } catch {}
+  }
+  if (!token) {
+    // Prompt user for token once if not provided
+    const t = window.prompt('Enter API token');
+    if (t) {
+      token = t;
+      try { localStorage.setItem('auth_token', token); } catch {}
+    }
+  }
+
+  const origFetch = window.fetch.bind(window);
+  window.fetch = (input, init = {}) => {
+    init.headers = init.headers || {};
+    if (token && !init.headers.Authorization && !init.headers.authorization) {
+      init.headers.Authorization = `Bearer ${token}`;
+    }
+    return origFetch(input, init);
+  };
+
+  const OrigEventSource = window.EventSource;
+  function EventSourceAuth(url, opts) {
+    const u = new URL(url, window.location.origin);
+    if (token && !u.searchParams.get('token')) {
+      u.searchParams.set('token', token);
+    }
+    return new OrigEventSource(u, opts);
+  }
+  EventSourceAuth.prototype = OrigEventSource.prototype;
+  EventSourceAuth.CONNECTING = OrigEventSource.CONNECTING;
+  EventSourceAuth.OPEN = OrigEventSource.OPEN;
+  EventSourceAuth.CLOSED = OrigEventSource.CLOSED;
+  window.EventSource = EventSourceAuth;
+}
+
+export function getToken() {
+  return token;
+}

--- a/client/public/assets/nav.js
+++ b/client/public/assets/nav.js
@@ -1,3 +1,5 @@
+import './auth.js';
+
 export async function initNav(doc = document, loc = window.location) {
   const nav = doc.querySelector('nav');
   if (!nav) return;

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -33,11 +33,14 @@ function verifyToken(token, secret = SECRET) {
 export async function auth(req, res, next) {
   if (!SECRET) return res.status(500).json({ error: 'auth_disabled' });
   const header = req.headers['authorization'] || '';
+  let token = null;
   const match = header.match(/^Bearer (.+)$/);
-  if (!match) return res.status(401).json({ error: 'unauthorized' });
+  if (match) token = match[1];
+  else if (req.query && req.query.token) token = String(req.query.token);
+  if (!token) return res.status(401).json({ error: 'unauthorized' });
   let payload;
   try {
-    payload = verifyToken(match[1]);
+    payload = verifyToken(token);
   } catch {
     return res.status(401).json({ error: 'unauthorized' });
   }

--- a/tests/integration/auth.middleware.test.js
+++ b/tests/integration/auth.middleware.test.js
@@ -58,6 +58,11 @@ describe('auth middleware', () => {
     expect(res.status).toBe(200);
   });
 
+  test('allows token via query', async () => {
+    const res = await request(app).get(`/live?token=${token}`);
+    expect(res.status).toBe(200);
+  });
+
   test('denies inactive subscriber', async () => {
     mockDb.query.mockResolvedValueOnce({ rows: [{ status: 'canceled' }] });
     const res = await request(app).get('/live').set('Authorization', `Bearer ${token}`);


### PR DESCRIPTION
## Summary
- add browser script to persist token and inject Authorization headers
- allow auth middleware to accept token via query parameter
- cover query-based auth in tests

## Testing
- `npm test` (fails: Could not find a working container runtime strategy, ReferenceError: document is not defined)
- `npm test tests/integration/auth.middleware.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd9cd834a48325a3a8f52417c5a030