### PR TITLE
frontend: apply auth for backtest job calls

### DIFF
--- a/client/public/assets/analytics.js
+++ b/client/public/assets/analytics.js
@@ -1,3 +1,4 @@
+import './auth.js';
 import { showToast } from './ui-toast.js';
 import {
   composeAnalyticsQuery,


### PR DESCRIPTION
## Summary
- include auth helper in analytics page so backtest job requests send token

## Testing
- `npm test` *(fails: ReferenceError: document is not defined, missing container runtime, and other jsdom-related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bda1a646208325a2c4fdf8baf4e0df