### PR TITLE
feat(auth): allow JWT via cookie

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,8 +1,13 @@
 # Authentication
 
 Sensitive API routes are protected using [JSON Web Tokens](https://jwt.io/).
-Clients must send a valid JWT in the `Authorization` header for the following
-paths:
+Clients must provide a valid JWT via one of the following for these paths:
+
+- `Authorization` header
+- `token` query parameter
+- `auth_token` cookie
+
+The protected paths are:
 
 - `/live` and subroutes
 - `/risk/*`
@@ -13,7 +18,7 @@ paths:
 Tokens use the `HS256` algorithm and are validated with the shared secret
 provided via the `AUTH_SECRET` environment variable.
 
-Example request:
+Example request using the `Authorization` header:
 
 ```http
 GET /live HTTP/1.1

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -37,6 +37,9 @@ export async function auth(req, res, next) {
   const match = header.match(/^Bearer (.+)$/);
   if (match) token = match[1];
   else if (req.query && req.query.token) token = String(req.query.token);
+  else if (req.cookies && (req.cookies.auth_token || req.cookies.token)) {
+    token = req.cookies.auth_token || req.cookies.token;
+  }
   if (!token) return res.status(401).json({ error: 'unauthorized' });
   let payload;
   try {

--- a/tests/integration/auth.middleware.test.js
+++ b/tests/integration/auth.middleware.test.js
@@ -63,6 +63,11 @@ describe('auth middleware', () => {
     expect(res.status).toBe(200);
   });
 
+  test('allows token via cookie', async () => {
+    const res = await request(app).get('/live').set('Cookie', `auth_token=${token}`);
+    expect(res.status).toBe(200);
+  });
+
   test('denies inactive subscriber', async () => {
     mockDb.query.mockResolvedValueOnce({ rows: [{ status: 'canceled' }] });
     const res = await request(app).get('/live').set('Authorization', `Bearer ${token}`);


### PR DESCRIPTION
## Summary
- accept JWT tokens from `auth_token` or `token` cookies in auth middleware
- document supported token delivery methods
- cover cookie-based auth in integration tests

## Testing
- `npm test` *(fails: ReferenceError: document is not defined, Could not find a working container runtime strategy, SyntaxError: Unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68beb74fa1948325b5a804df5db0599b