### PR TITLE
feat(nav): add jobs page link

### DIFF
--- a/client/public/partials/nav.html
+++ b/client/public/partials/nav.html
@@ -6,6 +6,7 @@
   <nav class="nav__links">
     <a href="/live.html"        data-link="live">Live</a>
     <a href="/analytics.html"   data-link="analytics">Analytics</a>
+    <a href="/jobs.html"        data-link="jobs">Jobs</a>
     <a href="/portfolio.html"   data-link="portfolio">Portfolio</a>
     <a href="/settings.html"    data-link="settings">Settings</a>
   </nav>

--- a/tests/fixtures/nav.html
+++ b/tests/fixtures/nav.html
@@ -2,5 +2,6 @@
   <a href="index.html">Home</a>
   <a href="live.html">Live</a>
   <a href="analytics.html">Analytics</a>
+  <a href="jobs.html">Jobs</a>
   <a href="settings.html">Settings</a>
 </nav>


### PR DESCRIPTION
## Summary
- add Jobs link to main navigation so the Jobs page is accessible directly
- update navigation fixture for tests

## Testing
- `npm test tests/client/nav.test.js`
- `npm run test:client tests/client/nav.test.js tests/client/nav.ext.test.js tests/client/nav.auto.test.js tests/unit/smoke.nav.test.js` *(fails: Not implemented: window.prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bebb01092483259442701673aeb792