### PR TITLE
feat(nav): add jobs page link and layout

### DIFF
--- a/client/public/jobs.html
+++ b/client/public/jobs.html
@@ -6,6 +6,8 @@
   <link rel="stylesheet" href="/assets/nav.css">
   <link rel="stylesheet" href="/assets/ui-breadcrumbs.css">
   <style>
+    .container { padding:24px; }
+    .card { border:1px solid #222; padding:16px; border-radius:8px; background:#111; }
     table { border-collapse: collapse; width: 100%; }
     th, td { border: 1px solid #333; padding: 4px 8px; }
     #log { background:#000; color:#0f0; padding:8px; height:200px; overflow:auto; white-space:pre-wrap; }
@@ -16,41 +18,47 @@
 <body>
   <div id="app-nav"></div>
   <div id="app-breadcrumbs"></div>
+  <div id="toasts" aria-live="polite"></div>
 
-  <section style="padding:16px;">
-    <h1>Jobs</h1>
+  <main class="container">
+    <section class="card">
+      <h1>Jobs</h1>
 
-    <h2>New Job</h2>
-    <form id="job-form">
-      <label>Type
-        <select id="job-type">
-          <option value="backtest">backtest</option>
-          <option value="optimize">optimize</option>
-          <option value="walkforward">walkforward</option>
-        </select>
-      </label>
-      <label>Params JSON
-        <textarea id="job-params" rows="4" cols="40">{"symbol":"BTCUSDT"}</textarea>
-      </label>
-      <button type="submit">Create</button>
-    </form>
+      <h2>New Job</h2>
+      <form id="job-form">
+        <label>Type
+          <select id="job-type">
+            <option value="backtest">backtest</option>
+            <option value="optimize">optimize</option>
+            <option value="walkforward">walkforward</option>
+          </select>
+        </label>
+        <label>Params JSON
+          <textarea id="job-params" rows="4" cols="40">{"symbol":"BTCUSDT"}</textarea>
+        </label>
+        <button type="submit">Create</button>
+      </form>
 
-    <h2>Jobs</h2>
-    <table id="jobs-table">
-      <thead><tr><th>ID</th><th>Type</th><th>Status</th><th>Progress</th><th>Actions</th></tr></thead>
-      <tbody></tbody>
-    </table>
+      <h2>Jobs</h2>
+      <table id="jobs-table">
+        <thead><tr><th>ID</th><th>Type</th><th>Status</th><th>Progress</th><th>Actions</th></tr></thead>
+        <tbody></tbody>
+      </table>
 
-    <div id="detail" style="margin-top:24px;display:none;">
-        <h2>Job Detail <span id="detail-id"></span> <span id="detail-trace"></span></h2>
-      <div class="progress"><div id="detail-progress"></div></div>
-      <pre id="log"></pre>
-      <ul id="artifacts"></ul>
-    </div>
-  </section>
+      <div id="detail" style="margin-top:24px;display:none;">
+          <h2>Job Detail <span id="detail-id"></span> <span id="detail-trace"></span></h2>
+        <div class="progress"><div id="detail-progress"></div></div>
+        <pre id="log"></pre>
+        <ul id="artifacts"></ul>
+      </div>
+    </section>
+  </main>
 
-  <script src="/assets/nav.js"></script>
-  <script src="/assets/ui-breadcrumbs.js"></script>
+  <div id="app-footer"></div>
+
+  <script type="module" src="/assets/nav.js"></script>
+  <script type="module" src="/assets/ui-breadcrumbs.js"></script>
+  <script type="module" src="/assets/ui-toast.js"></script>
     <script>
       function BadgeTrace(meta){
         if (!meta?.trace_id) return '';

--- a/client/public/partials/nav.html
+++ b/client/public/partials/nav.html
@@ -6,6 +6,7 @@
   <nav class="nav__links">
     <a href="/live.html"        data-link="live">Live</a>
     <a href="/analytics.html"   data-link="analytics">Analytics</a>
+    <a href="/jobs.html"        data-link="jobs">Jobs</a>
     <a href="/portfolio.html"   data-link="portfolio">Portfolio</a>
     <a href="/settings.html"    data-link="settings">Settings</a>
   </nav>

--- a/tests/fixtures/nav.html
+++ b/tests/fixtures/nav.html
@@ -2,5 +2,6 @@
   <a href="index.html">Home</a>
   <a href="live.html">Live</a>
   <a href="analytics.html">Analytics</a>
+  <a href="jobs.html">Jobs</a>
   <a href="settings.html">Settings</a>
 </nav>


### PR DESCRIPTION
## Summary
- add Jobs link to main navigation so the Jobs page is accessible directly
- structure Jobs page with shared nav, breadcrumbs, toast container, and footer

## Testing
- `npm test tests/client/nav.test.js`
- `npm run test:client tests/client/nav.test.js tests/client/nav.ext.test.js tests/client/nav.auto.test.js tests/unit/smoke.nav.test.js` *(fails: Cannot read properties of undefined (reading 'prototype'); Not implemented: window.prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bebb01092483259442701673aeb792