### PR TITLE
Fix live page tabs and add start/stop controls

### DIFF
--- a/client/public/assets/live.js
+++ b/client/public/assets/live.js
@@ -1,0 +1,74 @@
+import { mount as lazyMount } from './ui-lazy.js';
+import { showToast } from './ui-toast.js';
+
+const modules = {};
+
+function register(name, path){
+  window.UILazy.register(name, async () => {
+    modules[name] = await import(path);
+  });
+}
+
+async function mountModule(name, root){
+  await lazyMount(name, async () => {
+    const mod = modules[name];
+    if (!mod) return;
+    modules[name].instance = await mod.mount(root);
+  });
+}
+
+function unmountOthers(active){
+  for (const [name, mod] of Object.entries(modules)){
+    if (name !== active && mod.instance && typeof mod.instance.unmount === 'function'){
+      try { mod.instance.unmount(); } catch {}
+      mod.instance = null;
+    }
+  }
+}
+
+async function handleTab(tab, doc=document){
+  const name = tab?.dataset?.module;
+  const panelId = tab?.getAttribute('aria-controls');
+  if (!name || !panelId) return;
+  const root = doc.querySelector(`#${panelId} .panel-body`);
+  if (!root) return;
+  await mountModule(name, root);
+  unmountOthers(name);
+}
+
+function initTabs(doc=document){
+  const tabs = Array.from(doc.querySelectorAll('#live-tabs [role="tab"]'));
+  tabs.forEach(t => t.addEventListener('click', () => handleTab(t, doc)));
+  const selected = tabs.find(t => t.getAttribute('aria-selected') === 'true') || tabs[0];
+  if (selected) handleTab(selected, doc);
+}
+
+async function post(url){
+  try {
+    const res = await fetch(url, { method: 'POST' });
+    if (!res.ok) throw new Error(`${res.status}`);
+    showToast(url.endsWith('start') ? 'Started' : 'Stopped', { type: 'success' });
+  } catch (e) {
+    showToast(`Error ${e.message}`, { type: 'error' });
+  }
+}
+
+export function init(doc=document){
+  register('liveEquity', './modules/live/equity.js');
+  register('liveHistory', './modules/live/history.js');
+  register('liveOrders', './modules/live/orders.js');
+  register('liveRisk', './modules/live/risk.js');
+
+  initTabs(doc);
+
+  const startBtn = doc.querySelector('[data-live-start]');
+  const stopBtn = doc.querySelector('[data-live-stop]');
+  if (startBtn) startBtn.addEventListener('click', () => post('/live/start'));
+  if (stopBtn) stopBtn.addEventListener('click', () => post('/live/stop'));
+}
+
+if (typeof window !== 'undefined' && !window.__DISABLE_AUTO_INIT__){
+  window.addEventListener('DOMContentLoaded', () => init());
+}
+
+export default { init };

--- a/client/public/live.html
+++ b/client/public/live.html
@@ -12,7 +12,13 @@
   <div id="app-nav"></div>
   <div id="app-breadcrumbs"></div>
 
+  <div id="toasts" aria-live="polite"></div>
+
   <main class="container">
+    <div class="live-controls">
+      <button data-live-start>Start</button>
+      <button data-live-stop>Stop</button>
+    </div>
     <div class="ui-tabs" id="live-tabs" role="tablist">
       <button role="tab" aria-controls="live-equity" data-module="liveEquity">Equity</button>
       <button role="tab" aria-controls="live-history" data-module="liveHistory">History</button>
@@ -40,5 +46,6 @@
     <script type="module" src="/assets/ui-tabs.js"></script>
     <script type="module" src="/assets/ui-lazy.js"></script>
     <script type="module" src="/assets/ui-loader.js"></script>
+    <script type="module" src="/assets/live.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add start/stop controls and toast container to live page
- implement live.js to lazy-load live modules and call /live/start and /live/stop

## Testing
- `npm test` (fails: ReferenceError document is not defined, container runtime missing)
- `npm run test:client` (fails: mockClear is not a function)

------
https://chatgpt.com/codex/tasks/task_e_68c02b29540483259defd595ced76c88