### PR TITLE
Fix job log order in job detail views

### DIFF
--- a/client/public/assets/jobs.js
+++ b/client/public/assets/jobs.js
@@ -51,7 +51,9 @@ async function showDetail(id){
   const res = await fetch(`/jobs/${id}`);
   const data = await res.json();
   document.getElementById('detail-id').textContent = id;
-  document.getElementById('log').textContent = data.logs.map(l=>`[${l.level}] ${l.msg}`).join('\n');
+  // Display logs in chronological order
+  const logs = (data.logs || []).sort((a,b)=>a.id-b.id);
+  document.getElementById('log').textContent = logs.map(l=>`[${l.level}] ${l.msg}`).join('\n');
   document.getElementById('artifacts').innerHTML = data.artifacts.map(a=>`<li><a href="/jobs/${id}/artifacts/${a.id}/download">${a.label||a.kind}</a></li>`).join('');
   document.getElementById('detail').style.display='block';
   updateProgress(id, data.job.progress||0);

--- a/src/jobs/runners/backtest.js
+++ b/src/jobs/runners/backtest.js
@@ -3,12 +3,12 @@ import { writeCSV, writeJSON } from '../fs.js';
 function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 
 export async function run(job, { log, progress, signal }) {
-  log('info', `backtest start for ${job.params?.symbol || ''}`);
+  await log('info', `backtest start for ${job.params?.symbol || ''}`);
   for (let i = 0; i < 5; i++) {
     if (signal?.aborted) throw new Error('canceled');
     await sleep(200);
-    progress((i + 1) / 5);
-    log('info', `step ${i + 1}`);
+    await progress((i + 1) / 5);
+    await log('info', `step ${i + 1}`);
   }
   const tradesCsv = 'id,ts,side,qty,price\n';
   await writeCSV(job.id, job.type, 'trades.csv', tradesCsv, 'Trades');

--- a/src/jobs/runners/optimize.js
+++ b/src/jobs/runners/optimize.js
@@ -7,8 +7,8 @@ export async function run(job, { log, progress, signal }) {
   for (let i = 0; i < total; i++) {
     if (signal?.aborted) throw new Error('canceled');
     await sleep(200);
-    progress((i + 1) / total);
-    log('info', `combo ${i + 1} / ${total}`);
+    await progress((i + 1) / total);
+    await log('info', `combo ${i + 1} / ${total}`);
   }
   await writeCSV(job.id, job.type, 'optimize_results.csv', 'params,metric\n', 'Optimize Results');
   const result = { best: null };

--- a/src/jobs/runners/walkforward.js
+++ b/src/jobs/runners/walkforward.js
@@ -7,8 +7,8 @@ export async function run(job, { log, progress, signal }) {
   for (let i = 0; i < total; i++) {
     if (signal?.aborted) throw new Error('canceled');
     await sleep(200);
-    progress((i + 1) / total);
-    log('info', `window ${i + 1} / ${total}`);
+    await progress((i + 1) / total);
+    await log('info', `window ${i + 1} / ${total}`);
   }
   await writeCSV(job.id, job.type, 'wf_oos_equity.csv', 'ts,equity\n', 'WF Equity');
   const result = { windows: total };

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -34,7 +34,8 @@ router.get('/jobs/:id', async (req, res) => {
   if (!jobs.length) return res.status(404).json({ error: 'not_found' });
   const job = jobs[0];
   const { rows: artifacts } = await db.query('SELECT * FROM job_artifacts WHERE job_id=$1 ORDER BY id ASC', [id]);
-  const { rows: logs } = await db.query('SELECT * FROM job_logs WHERE job_id=$1 ORDER BY id DESC LIMIT 100', [id]);
+  // Return logs in chronological order for easier reading in the UI
+  const { rows: logs } = await db.query('SELECT * FROM job_logs WHERE job_id=$1 ORDER BY id ASC LIMIT 100', [id]);
   res.json({ job, artifacts, logs });
 });
 


### PR DESCRIPTION
## Summary
- ensure `/jobs/:id` API returns logs in chronological order
- show job logs chronologically in jobs.html detail view
- await progress and log writes in job runners so logs persist

## Testing
- `npm test` *(fails: ReferenceError: document is not defined; Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68c0668ff37c8325ad8dba43300e8c2d