### PR TITLE
Show strategies on settings page

### DIFF
--- a/client/public/assets/settings.js
+++ b/client/public/assets/settings.js
@@ -1,0 +1,46 @@
+import './auth.js';
+
+async function loadConfig(){
+  const strategiesPanel = document.getElementById('panel-strategies');
+  const presetsPanel = document.getElementById('panel-presets');
+  strategiesPanel.innerHTML = '<p>Loading...</p>';
+  presetsPanel.innerHTML = '<p>Loading...</p>';
+  try {
+    const res = await fetch('/config/strategies');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const strategies = data.active?.strategies || [];
+    if (strategies.length === 0){
+      strategiesPanel.innerHTML = '<p>No strategies configured.</p>';
+    } else {
+      const list = document.createElement('ul');
+      for (const s of strategies){
+        const li = document.createElement('li');
+        const symbols = (s.symbols || []).join(', ');
+        li.innerHTML = `<strong>${s.id}</strong> - ${symbols} - <code>${JSON.stringify(s.params || {})}</code>`;
+        list.appendChild(li);
+      }
+      strategiesPanel.innerHTML = '';
+      strategiesPanel.appendChild(list);
+    }
+    const presets = data.presets || [];
+    if (presets.length === 0){
+      presetsPanel.innerHTML = '<p>No presets.</p>';
+    } else {
+      const list = document.createElement('ul');
+      for (const p of presets){
+        const li = document.createElement('li');
+        li.innerHTML = `<strong>${p.name}</strong> - ${p.strategy_id}`;
+        list.appendChild(li);
+      }
+      presetsPanel.innerHTML = '';
+      presetsPanel.appendChild(list);
+    }
+  } catch (err) {
+    console.error('Failed to load config', err);
+    strategiesPanel.innerHTML = '<p>Failed to load strategies.</p>';
+    presetsPanel.innerHTML = '<p>Failed to load presets.</p>';
+  }
+}
+
+loadConfig();

--- a/client/public/settings.html
+++ b/client/public/settings.html
@@ -31,5 +31,6 @@
   <script type="module" src="/assets/nav.js"></script>
   <script type="module" src="/assets/ui-breadcrumbs.js"></script>
   <script type="module" src="/assets/ui-tabs.js"></script>
+  <script type="module" src="/assets/settings.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add `settings.js` to fetch strategy/preset config and populate the settings page
- Load the new script from `settings.html`

## Testing
- `npm run test:client`
- `npm test tests/client/analytics.ui.test.js` *(fails: ReferenceError: document is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68c0779ccc008325a821d043371b5106