### PR TITLE
feat: lazy load portfolio modules

### DIFF
--- a/client/public/assets/portfolio.js
+++ b/client/public/assets/portfolio.js
@@ -1,0 +1,72 @@
+import { mount as lazyMount } from './ui-lazy.js';
+
+const modules = {};
+const vendors = new Map();
+
+function loadScript(src) {
+  if (!vendors.has(src)) {
+    vendors.set(src, new Promise((resolve, reject) => {
+      const s = document.createElement('script');
+      s.src = src;
+      s.onload = () => resolve();
+      s.onerror = () => reject(new Error(`Failed to load ${src}`));
+      document.head.appendChild(s);
+    }));
+  }
+  return vendors.get(src);
+}
+
+function register(doc = document) {
+  const panels = Array.from(doc.querySelectorAll('[data-tab-panel][data-lazy-module]'));
+  panels.forEach(p => {
+    const name = p.dataset.tabPanel;
+    const modPath = p.dataset.lazyModule;
+    const vendorPath = p.dataset.lazyVendor;
+    window.UILazy.register(name, async () => {
+      if (vendorPath) await loadScript(vendorPath);
+      modules[name] = await import(modPath);
+    });
+  });
+}
+
+async function mountModule(name, root) {
+  await lazyMount(name, async () => {
+    const mod = modules[name];
+    if (!mod) return;
+    modules[name].instance = await mod.mount(root);
+  });
+}
+
+function unmountOthers(active) {
+  for (const [n, mod] of Object.entries(modules)) {
+    if (n !== active && mod.instance && typeof mod.instance.unmount === 'function') {
+      try { mod.instance.unmount(); } catch {}
+      mod.instance = null;
+    }
+  }
+}
+
+async function handleTab(tab, doc = document) {
+  const name = tab?.dataset?.tab;
+  const panelId = tab?.getAttribute('aria-controls');
+  if (!name || !panelId) return;
+  const panel = doc.getElementById(panelId);
+  if (!panel) return;
+  await mountModule(name, panel);
+  unmountOthers(name);
+}
+
+export function init(doc = document) {
+  register(doc);
+  const tabs = Array.from(doc.querySelectorAll('[role="tab"][data-tab]'));
+  tabs.forEach(t => t.addEventListener('click', () => handleTab(t, doc)));
+  const selected = tabs.find(t => t.getAttribute('aria-selected') === 'true') || tabs[0];
+  if (selected) handleTab(selected, doc);
+}
+
+if (typeof window !== 'undefined' && !window.__DISABLE_AUTO_INIT__) {
+  window.addEventListener('DOMContentLoaded', () => init());
+}
+
+export default { init };
+

--- a/client/public/portfolio.html
+++ b/client/public/portfolio.html
@@ -14,11 +14,11 @@
   <main class="container">
     <div class="tabs" data-tabs id="portfolio-tabs">
       <div class="tablist" role="tablist" aria-label="Portfolio sections">
-        <button role="tab" id="tab-alloc" data-tab="alloc" aria-selected="true">Allocation</button>
-        <button role="tab" id="tab-risk" data-tab="risk">Risk</button>
-        <button role="tab" id="tab-corr" data-tab="corr">Correlation</button>
-        <button role="tab" id="tab-attr" data-tab="attr">Attribution</button>
-        <button role="tab" id="tab-eq" data-tab="eq">Equity</button>
+        <button role="tab" id="tab-alloc" data-tab="alloc" aria-controls="panel-alloc" aria-selected="true">Allocation</button>
+        <button role="tab" id="tab-risk" data-tab="risk" aria-controls="panel-risk">Risk</button>
+        <button role="tab" id="tab-corr" data-tab="corr" aria-controls="panel-corr">Correlation</button>
+        <button role="tab" id="tab-attr" data-tab="attr" aria-controls="panel-attr">Attribution</button>
+        <button role="tab" id="tab-eq" data-tab="eq" aria-controls="panel-eq">Equity</button>
       </div>
 
       <section role="tabpanel" id="panel-alloc" data-tab-panel="alloc" aria-labelledby="tab-alloc"
@@ -47,5 +47,6 @@
   <script type="module" src="/assets/ui-breadcrumbs.js"></script>
   <script type="module" src="/assets/ui-tabs.js"></script>
   <script type="module" src="/assets/ui-lazy.js"></script>
+  <script type="module" src="/assets/portfolio.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- lazy load portfolio tab modules with UILazy
- link tabs to panels via aria-controls for proper selection

## Testing
- `npm test` *(fails: document is not defined, container runtime errors)*
- `npm run lint` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c07e7e470c8325aa8b2fac565f7bdc